### PR TITLE
Add ML99_NO_SHORT_NAMES to disable v() macro alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,5 +6,11 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)
 endif()
 
+option(METALANG99_NO_SHORT_NAMES "Disable short macro aliases (e.g., v) for compatibility" OFF)
+
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+if(METALANG99_NO_SHORT_NAMES)
+    target_compile_definitions(${PROJECT_NAME} INTERFACE ML99_NO_SHORT_NAMES)
+endif()

--- a/README.md
+++ b/README.md
@@ -212,6 +212,31 @@ Optionally, you can [precompile headers] in your project that rely on Metalang99
 
 Happy hacking!
 
+### Short macro aliases
+
+Metalang99 provides a short macro alias `v(...)` for `ML99_QUOTE(...)`. In some projects, single-letter macros can conflict with other libraries (for example, Qt headers that use `v` in constructor initializers).
+
+If you want to avoid exporting short names, define `ML99_NO_SHORT_NAMES` before including any Metalang99 headers:
+
+```c
+#define ML99_NO_SHORT_NAMES
+#include <metalang99.h>
+```
+
+With CMake, add the definition to your target:
+
+```cmake
+target_compile_definitions(your_target PRIVATE ML99_NO_SHORT_NAMES)
+```
+
+Or pass it at configure time:
+
+```sh
+cmake -DMETALANG99_NO_SHORT_NAMES=ON ..
+```
+
+> **Tip:** Using `ML99_QUOTE(...)` directly is always safe and avoids macro-name collisions.
+
 ## Highlights
 
  - **Macro recursion.** Recursive calls behave as expected. In particular, to implement recursion, [Boost/Preprocessor] just copy-pastes all recursive functions up to a certain limit and forces to either keep track of recursion depth or rely on their built-in deduction. Being an interpreter, Metalang99 is free from such drawbacks.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,24 @@ Sometimes, there exist two versions of the same macro: one is plain, and the oth
 
 Both metaprograms result in `1, 2, 3`.
 
+Short macro aliases
+-------------------
+
+The macro `v(...)` is a short alias for `ML99_QUOTE(...)`. To disable this alias, define `ML99_NO_SHORT_NAMES` before including Metalang99 headers:
+
+.. code:: c
+
+    #define ML99_NO_SHORT_NAMES
+    #include <metalang99.h>
+
+With CMake, add the definition to your target:
+
+.. code:: cmake
+
+    target_compile_definitions(your_target PRIVATE ML99_NO_SHORT_NAMES)
+
+``ML99_QUOTE(...)`` is always available and is recommended in public headers and in C++ projects that include third-party libraries such as Qt.
+
 Version manipulation macros
 ---------------------------
 

--- a/include/metalang99/assert.h
+++ b/include/metalang99/assert.h
@@ -39,7 +39,7 @@
  * @code
  * #include <metalang99/assert.h>
  *
- * ML99_ASSERT(v(123 == 123));
+ * ML99_ASSERT(ML99_QUOTE(123 == 123));
  * @endcode
  */
 #define ML99_ASSERT(expr) ML99_ASSERT_EQ(expr, ML99_true())
@@ -52,7 +52,7 @@
  * @code
  * #include <metalang99/assert.h>
  *
- * ML99_ASSERT_EQ(v(123), v(123));
+ * ML99_ASSERT_EQ(ML99_QUOTE(123), ML99_QUOTE(123));
  * @endcode
  */
 #define ML99_ASSERT_EQ(lhs, rhs) ML99_ASSERT_UNEVAL((ML99_EVAL(lhs)) == (ML99_EVAL(rhs)))
@@ -80,10 +80,10 @@
  * #include <metalang99/assert.h>
  *
  * // Passes:
- * ML99_ASSERT_EMPTY(v());
+ * ML99_ASSERT_EMPTY(ML99_QUOTE());
  *
  * // Fails:
- * ML99_ASSERT_EMPTY(v(123));
+ * ML99_ASSERT_EMPTY(ML99_QUOTE(123));
  * @endcode
  */
 #define ML99_ASSERT_EMPTY(expr) ML99_ASSERT_EMPTY_UNEVAL(ML99_EVAL(expr))
@@ -108,8 +108,8 @@
 
 #ifndef DOXYGEN_IGNORE
 
-#define ML99_assert_IMPL(expr)       v(ML99_ASSERT_UNEVAL(expr))
-#define ML99_assertEq_IMPL(lhs, rhs) v(ML99_ASSERT_UNEVAL((lhs) == (rhs)))
+#define ML99_assert_IMPL(expr)       ML99_QUOTE(ML99_ASSERT_UNEVAL(expr))
+#define ML99_assertEq_IMPL(lhs, rhs) ML99_QUOTE(ML99_ASSERT_UNEVAL((lhs) == (rhs)))
 
 #ifdef ML99_PRIV_C11_STATIC_ASSERT_AVAILABLE
 #define ML99_PRIV_ASSERT_UNEVAL_INNER(expr) _Static_assert((expr), "Metalang99 assertion failed")

--- a/include/metalang99/bool.h
+++ b/include/metalang99/bool.h
@@ -30,10 +30,10 @@
  * #include <metalang99/bool.h>
  *
  * // 1
- * ML99_not(v(0))
+ * ML99_not(ML99_QUOTE(0))
  *
  * // 0
- * ML99_not(v(1))
+ * ML99_not(ML99_QUOTE(1))
  * @endcode
  */
 #define ML99_not(x) ML99_call(ML99_not, x)
@@ -47,16 +47,16 @@
  * #include <metalang99/bool.h>
  *
  * // 0
- * ML99_and(v(0), v(0))
+ * ML99_and(ML99_QUOTE(0), ML99_QUOTE(0))
  *
  * // 0
- * ML99_and(v(0), v(1))
+ * ML99_and(ML99_QUOTE(0), ML99_QUOTE(1))
  *
  * // 0
- * ML99_and(v(1), v(0))
+ * ML99_and(ML99_QUOTE(1), ML99_QUOTE(0))
  *
  * // 1
- * ML99_and(v(1), v(1))
+ * ML99_and(ML99_QUOTE(1), ML99_QUOTE(1))
  * @endcode
  */
 #define ML99_and(x, y) ML99_call(ML99_and, x, y)
@@ -69,16 +69,16 @@
  * #include <metalang99/bool.h>
  *
  * // 0
- * ML99_or(v(0), v(0))
+ * ML99_or(ML99_QUOTE(0), ML99_QUOTE(0))
  *
  * // 1
- * ML99_or(v(0), v(1))
+ * ML99_or(ML99_QUOTE(0), ML99_QUOTE(1))
  *
  * // 1
- * ML99_or(v(1), v(0))
+ * ML99_or(ML99_QUOTE(1), ML99_QUOTE(0))
  *
  * // 1
- * ML99_or(v(1), v(1))
+ * ML99_or(ML99_QUOTE(1), ML99_QUOTE(1))
  * @endcode
  */
 #define ML99_or(x, y) ML99_call(ML99_or, x, y)
@@ -92,16 +92,16 @@
  * #include <metalang99/bool.h>
  *
  * // 0
- * ML99_xor(v(0), v(0))
+ * ML99_xor(ML99_QUOTE(0), ML99_QUOTE(0))
  *
  * // 1
- * ML99_xor(v(0), v(1))
+ * ML99_xor(ML99_QUOTE(0), ML99_QUOTE(1))
  *
  * // 1
- * ML99_xor(v(1), v(0))
+ * ML99_xor(ML99_QUOTE(1), ML99_QUOTE(0))
  *
  * // 0
- * ML99_xor(v(1), v(1))
+ * ML99_xor(ML99_QUOTE(1), ML99_QUOTE(1))
  * @endcode
  */
 #define ML99_xor(x, y) ML99_call(ML99_xor, x, y)
@@ -115,16 +115,16 @@
  * #include <metalang99/bool.h>
  *
  * // 1
- * ML99_boolEq(v(0), v(0))
+ * ML99_boolEq(ML99_QUOTE(0), ML99_QUOTE(0))
  *
  * // 0
- * ML99_boolEq(v(0), v(1))
+ * ML99_boolEq(ML99_QUOTE(0), ML99_QUOTE(1))
  *
  * // 0
- * ML99_boolEq(v(1), v(0))
+ * ML99_boolEq(ML99_QUOTE(1), ML99_QUOTE(0))
  *
  * // 1
- * ML99_boolEq(v(1), v(1))
+ * ML99_boolEq(ML99_QUOTE(1), ML99_QUOTE(1))
  * @endcode
  */
 #define ML99_boolEq(x, y) ML99_call(ML99_boolEq, x, y)
@@ -137,14 +137,14 @@
  * @code
  * #include <metalang99/bool.h>
  *
- * #define MATCH_1_IMPL() v(Billie)
- * #define MATCH_0_IMPL() v(Jean)
+ * #define MATCH_1_IMPL() ML99_QUOTE(Billie)
+ * #define MATCH_0_IMPL() ML99_QUOTE(Jean)
  *
  * // Billie
- * ML99_boolMatch(v(1), v(MATCH_))
+ * ML99_boolMatch(ML99_QUOTE(1), ML99_QUOTE(MATCH_))
  *
  * // Jean
- * ML99_boolMatch(v(0), v(MATCH_))
+ * ML99_boolMatch(ML99_QUOTE(0), ML99_QUOTE(MATCH_))
  * @endcode
  *
  * @note This function calls @p f with #ML99_call, so no partial application occurs, and so
@@ -160,14 +160,14 @@
  * @code
  * #include <metalang99/bool.h>
  *
- * #define MATCH_1_IMPL(x, y, z) v(Billie ~ x y z)
- * #define MATCH_0_IMPL(x, y, z) v(Jean ~ x y z)
+ * #define MATCH_1_IMPL(x, y, z) ML99_QUOTE(Billie ~ x y z)
+ * #define MATCH_0_IMPL(x, y, z) ML99_QUOTE(Jean ~ x y z)
  *
  * // Billie ~ 1 2 3
- * ML99_boolMatchWithArgs(v(1), v(MATCH_), v(1, 2, 3))
+ * ML99_boolMatchWithArgs(ML99_QUOTE(1), ML99_QUOTE(MATCH_), ML99_QUOTE(1, 2, 3))
  *
  * // Jean ~ 1 2 3
- * ML99_boolMatchWithArgs(v(0), v(MATCH_), v(1, 2, 3))
+ * ML99_boolMatchWithArgs(ML99_QUOTE(0), ML99_QUOTE(MATCH_), ML99_QUOTE(1, 2, 3))
  * @endcode
  */
 #define ML99_boolMatchWithArgs(x, matcher, ...)                                                    \
@@ -182,10 +182,10 @@
  * #include <metalang99/bool.h>
  *
  * // 123
- * ML99_if(v(1), v(123), v(18))
+ * ML99_if(ML99_QUOTE(1), ML99_QUOTE(123), ML99_QUOTE(18))
  *
  * // 18
- * ML99_if(v(0), v(123), v(18))
+ * ML99_if(ML99_QUOTE(0), ML99_QUOTE(123), ML99_QUOTE(18))
  * @endcode
  */
 #define ML99_if(cond, x, y) ML99_call(ML99_if, cond, x, y)
@@ -213,19 +213,19 @@
 
 #ifndef DOXYGEN_IGNORE
 
-#define ML99_true_IMPL(...)  v(ML99_TRUE())
-#define ML99_false_IMPL(...) v(ML99_FALSE())
+#define ML99_true_IMPL(...)  ML99_QUOTE(ML99_TRUE())
+#define ML99_false_IMPL(...) ML99_QUOTE(ML99_FALSE())
 
-#define ML99_not_IMPL(x)       v(ML99_NOT(x))
-#define ML99_and_IMPL(x, y)    v(ML99_AND(x, y))
-#define ML99_or_IMPL(x, y)     v(ML99_OR(x, y))
-#define ML99_xor_IMPL(x, y)    v(ML99_XOR(x, y))
-#define ML99_boolEq_IMPL(x, y) v(ML99_BOOL_EQ(x, y))
+#define ML99_not_IMPL(x)       ML99_QUOTE(ML99_NOT(x))
+#define ML99_and_IMPL(x, y)    ML99_QUOTE(ML99_AND(x, y))
+#define ML99_or_IMPL(x, y)     ML99_QUOTE(ML99_OR(x, y))
+#define ML99_xor_IMPL(x, y)    ML99_QUOTE(ML99_XOR(x, y))
+#define ML99_boolEq_IMPL(x, y) ML99_QUOTE(ML99_BOOL_EQ(x, y))
 
 #define ML99_boolMatch_IMPL(x, matcher)              ML99_callUneval(matcher##x, )
 #define ML99_boolMatchWithArgs_IMPL(x, matcher, ...) ML99_callUneval(matcher##x, __VA_ARGS__)
 
-#define ML99_if_IMPL(cond, x, y) v(ML99_PRIV_IF(cond, x, y))
+#define ML99_if_IMPL(cond, x, y) ML99_QUOTE(ML99_PRIV_IF(cond, x, y))
 
 // Arity specifiers {
 

--- a/include/metalang99/choice.h
+++ b/include/metalang99/choice.h
@@ -43,7 +43,7 @@
  * #include <metalang99/choice.h>
  *
  * // foo
- * ML99_choiceTag(ML99_choice(v(foo), v(1, 2, 3)))
+ * ML99_choiceTag(ML99_choice(ML99_QUOTE(foo), ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_choiceTag(choice) ML99_call(ML99_choiceTag, choice)
@@ -59,7 +59,7 @@
  * #include <metalang99/choice.h>
  *
  * // 1, 2, 3
- * ML99_choiceData(ML99_choice(v(foo), v(1, 2, 3)))
+ * ML99_choiceData(ML99_choice(ML99_QUOTE(foo), ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_choiceData(choice) ML99_call(ML99_choiceData, choice)
@@ -87,10 +87,10 @@
  * @code
  * #include <metalang99/choice.h>
  *
- * #define MATCH_A_IMPL(x, y, z) v(x ~ y ~ z)
+ * #define MATCH_A_IMPL(x, y, z) ML99_QUOTE(x ~ y ~ z)
  *
  * // 123 ~ 456 ~ 789
- * ML99_matchWithArgs(ML99_choice(v(A), v(123)), v(MATCH_), v(456, 789))
+ * ML99_matchWithArgs(ML99_choice(ML99_QUOTE(A), ML99_QUOTE(123)), ML99_QUOTE(MATCH_), ML99_QUOTE(456, 789))
  * @endcode
  */
 #define ML99_matchWithArgs(choice, matcher, ...)                                                   \
@@ -102,9 +102,9 @@
 
 #ifndef DOXYGEN_IGNORE
 
-#define ML99_choice_IMPL(tag, ...)   v(ML99_CHOICE(tag, __VA_ARGS__))
-#define ML99_choiceTag_IMPL(choice)  v(ML99_CHOICE_TAG(choice))
-#define ML99_choiceData_IMPL(choice) v(ML99_CHOICE_DATA(choice))
+#define ML99_choice_IMPL(tag, ...)   ML99_QUOTE(ML99_CHOICE(tag, __VA_ARGS__))
+#define ML99_choiceTag_IMPL(choice)  ML99_QUOTE(ML99_CHOICE_TAG(choice))
+#define ML99_choiceData_IMPL(choice) ML99_QUOTE(ML99_CHOICE_DATA(choice))
 
 #define ML99_match_IMPL(choice, matcher)                                                           \
     ML99_callUneval(ML99_PRIV_CAT(matcher, ML99_PRIV_HEAD_AUX choice), ML99_PRIV_TAIL_AUX choice)

--- a/include/metalang99/either.h
+++ b/include/metalang99/either.h
@@ -31,10 +31,10 @@
  * #include <metalang99/either.h>
  *
  * // 1
- * ML99_isLeft(ML99_left(v(123)))
+ * ML99_isLeft(ML99_left(ML99_QUOTE(123)))
  *
  * // 0
- * ML99_isLeft(ML99_right(v(123)))
+ * ML99_isLeft(ML99_right(ML99_QUOTE(123)))
  * @endcode
  */
 #define ML99_isLeft(either) ML99_call(ML99_isLeft, either)
@@ -48,10 +48,10 @@
  * #include <metalang99/either.h>
  *
  * // 1
- * ML99_isRight(ML99_right(v(123)))
+ * ML99_isRight(ML99_right(ML99_QUOTE(123)))
  *
  * // 0
- * ML99_isRight(ML99_left(v(123)))
+ * ML99_isRight(ML99_left(ML99_QUOTE(123)))
  * @endcode
  */
 #define ML99_isRight(either) ML99_call(ML99_isRight, either)
@@ -66,13 +66,13 @@
  * #include <metalang99/nat.h>
  *
  * // 1
- * ML99_eitherEq(v(ML99_natEq), ML99_left(v(123)), ML99_left(v(123)))
+ * ML99_eitherEq(ML99_QUOTE(ML99_natEq), ML99_left(ML99_QUOTE(123)), ML99_left(ML99_QUOTE(123)))
  *
  * // 0
- * ML99_eitherEq(v(ML99_natEq), ML99_right(v(123)), ML99_left(v(8)))
+ * ML99_eitherEq(ML99_QUOTE(ML99_natEq), ML99_right(ML99_QUOTE(123)), ML99_left(ML99_QUOTE(8)))
  *
  * // 0
- * ML99_eitherEq(v(ML99_natEq), ML99_right(v(123)), ML99_left(v(123)))
+ * ML99_eitherEq(ML99_QUOTE(ML99_natEq), ML99_right(ML99_QUOTE(123)), ML99_left(ML99_QUOTE(123)))
  * @endcode
  */
 #define ML99_eitherEq(cmp, either, other) ML99_call(ML99_eitherEq, cmp, either, other)
@@ -86,10 +86,10 @@
  * #include <metalang99/either.h>
  *
  * // 123
- * ML99_unwrapLeft(ML99_left(v(123)))
+ * ML99_unwrapLeft(ML99_left(ML99_QUOTE(123)))
  *
  * // Emits a fatal error.
- * ML99_unwrapLeft(ML99_right(v(123)))
+ * ML99_unwrapLeft(ML99_right(ML99_QUOTE(123)))
  * @endcode
  */
 #define ML99_unwrapLeft(either) ML99_call(ML99_unwrapLeft, either)
@@ -103,10 +103,10 @@
  * #include <metalang99/either.h>
  *
  * // 123
- * ML99_unwrapRight(ML99_right(v(123)))
+ * ML99_unwrapRight(ML99_right(ML99_QUOTE(123)))
  *
  * // Emits a fatal error.
- * ML99_unwrapRight(ML99_left(v(123)))
+ * ML99_unwrapRight(ML99_left(ML99_QUOTE(123)))
  * @endcode
  */
 #define ML99_unwrapRight(either) ML99_call(ML99_unwrapRight, either)
@@ -118,11 +118,11 @@
 
 #ifndef DOXYGEN_IGNORE
 
-#define ML99_left_IMPL(x)  v(ML99_LEFT(x))
-#define ML99_right_IMPL(x) v(ML99_RIGHT(x))
+#define ML99_left_IMPL(x)  ML99_QUOTE(ML99_LEFT(x))
+#define ML99_right_IMPL(x) ML99_QUOTE(ML99_RIGHT(x))
 
-#define ML99_isLeft_IMPL(either)  v(ML99_IS_LEFT(either))
-#define ML99_isRight_IMPL(either) v(ML99_IS_RIGHT(either))
+#define ML99_isLeft_IMPL(either)  ML99_QUOTE(ML99_IS_LEFT(either))
+#define ML99_isRight_IMPL(either) ML99_QUOTE(ML99_IS_RIGHT(either))
 
 // ML99_eitherEq_IMPL {
 
@@ -142,14 +142,14 @@
 // } (ML99_eitherEq_IMPL)
 
 #define ML99_unwrapLeft_IMPL(either)      ML99_match_IMPL(either, ML99_PRIV_unwrapLeft_)
-#define ML99_PRIV_unwrapLeft_left_IMPL(x) v(x)
+#define ML99_PRIV_unwrapLeft_left_IMPL(x) ML99_QUOTE(x)
 #define ML99_PRIV_unwrapLeft_right_IMPL(_x)                                                        \
     ML99_fatal(ML99_unwrapLeft, expected ML99_left but found ML99_right)
 
 #define ML99_unwrapRight_IMPL(either) ML99_match_IMPL(either, ML99_PRIV_unwrapRight_)
 #define ML99_PRIV_unwrapRight_left_IMPL(_x)                                                        \
     ML99_fatal(ML99_unwrapRight, expected ML99_right but found ML99_left)
-#define ML99_PRIV_unwrapRight_right_IMPL(x) v(x)
+#define ML99_PRIV_unwrapRight_right_IMPL(x) ML99_QUOTE(x)
 
 #define ML99_PRIV_IS_LEFT(either) ML99_DETECT_IDENT(ML99_PRIV_IS_LEFT_, ML99_CHOICE_TAG(either))
 #define ML99_PRIV_IS_LEFT_left    ()

--- a/include/metalang99/gen.h
+++ b/include/metalang99/gen.h
@@ -30,7 +30,7 @@
  * #include <metalang99/gen.h>
  *
  * // int x = 5;
- * ML99_semicoloned(v(int x = 5))
+ * ML99_semicoloned(ML99_QUOTE(int x = 5))
  * @endcode
  */
 #define ML99_semicoloned(...) ML99_call(ML99_semicoloned, __VA_ARGS__)
@@ -44,7 +44,7 @@
  * #include <metalang99/gen.h>
  *
  * // { int a, b, c; }
- * ML99_braced(v(int a, b, c;))
+ * ML99_braced(ML99_QUOTE(int a, b, c;))
  * @endcode
  */
 #define ML99_braced(...) ML99_call(ML99_braced, __VA_ARGS__)
@@ -58,7 +58,7 @@
  * #include <metalang99/gen.h>
  *
  * // x = 5, 6, 7
- * ML99_assign(v(x), v(5, 6, 7))
+ * ML99_assign(ML99_QUOTE(x), ML99_QUOTE(5, 6, 7))
  * @endcode
  */
 #define ML99_assign(lhs, ...) ML99_call(ML99_assign, lhs, __VA_ARGS__)
@@ -88,7 +88,7 @@
  * #include <metalang99/gen.h>
  *
  * // If you are on C11.
- * ML99_invoke(v(_Static_assert), v(1 == 1, "Must be true"))
+ * ML99_invoke(ML99_QUOTE(_Static_assert), ML99_QUOTE(1 == 1, "Must be true"))
  * @endcode
  */
 #define ML99_invoke(f, ...) ML99_call(ML99_invoke, f, __VA_ARGS__)
@@ -109,7 +109,7 @@
  * // if (1 == 1) {
  * //     printf("x = %d\n", x);
  * // }
- * ML99_prefixedBlock(v(if (1 == 1)), v(printf("x = %d\n", x);))
+ * ML99_prefixedBlock(ML99_QUOTE(if (1 == 1)), ML99_QUOTE(printf("x = %d\n", x);))
  * @endcode
  */
 #define ML99_prefixedBlock(prefix, ...) ML99_call(ML99_prefixedBlock, prefix, __VA_ARGS__)
@@ -123,7 +123,7 @@
  * #include <metalang99/gen.h>
  *
  * // typedef struct { int x, y; } Point;
- * ML99_typedef(v(Point), v(struct { int x, y; }))
+ * ML99_typedef(ML99_QUOTE(Point), ML99_QUOTE(struct { int x, y; }))
  * @endcode
  */
 #define ML99_typedef(ident, ...) ML99_call(ML99_typedef, ident, __VA_ARGS__)
@@ -137,7 +137,7 @@
  * #include <metalang99/gen.h>
  *
  * // struct Point { int x, y; }
- * ML99_struct(v(Point), v(int x, y;))
+ * ML99_struct(ML99_QUOTE(Point), ML99_QUOTE(int x, y;))
  * @endcode
  */
 #define ML99_struct(ident, ...) ML99_call(ML99_struct, ident, __VA_ARGS__)
@@ -151,7 +151,7 @@
  * #include <metalang99/gen.h>
  *
  * // struct { int x, y; }
- * ML99_struct(v(int x, y;))
+ * ML99_struct(ML99_QUOTE(int x, y;))
  * @endcode
  */
 #define ML99_anonStruct(...) ML99_call(ML99_anonStruct, __VA_ARGS__)
@@ -185,10 +185,10 @@
  * #include <metalang99/gen.h>
  *
  * // int (*add)(int x, int y)
- * ML99_fnPtr(v(int), v(add), v(int x), v(int y))
+ * ML99_fnPtr(ML99_QUOTE(int), ML99_QUOTE(add), ML99_QUOTE(int x), ML99_QUOTE(int y))
  *
  * // const char *(*title)(void)
- * ML99_fnPtr(v(const char *), v(title), v(void))
+ * ML99_fnPtr(ML99_QUOTE(const char *), ML99_QUOTE(title), ML99_QUOTE(void))
  * @endcode
  */
 #define ML99_fnPtr(ret_ty, name, ...) ML99_call(ML99_fnPtr, ret_ty, name, __VA_ARGS__)
@@ -207,7 +207,7 @@
  * #include <metalang99/gen.h>
  *
  * // ~ ~ ~ ~ ~
- * ML99_times(v(5), v(~))
+ * ML99_times(ML99_QUOTE(5), ML99_QUOTE(~))
  * @endcode
  */
 #define ML99_times(n, ...) ML99_call(ML99_times, n, __VA_ARGS__)
@@ -222,7 +222,7 @@
  * #include <metalang99/util.h>
  *
  * // _0 _1 _2
- * ML99_repeat(v(3), ML99_appl(v(ML99_cat), v(_)))
+ * ML99_repeat(ML99_QUOTE(3), ML99_appl(ML99_QUOTE(ML99_cat), ML99_QUOTE(_)))
  * @endcode
  */
 #define ML99_repeat(n, f) ML99_call(ML99_repeat, n, f)
@@ -238,7 +238,7 @@
  * #include <metalang99/gen.h>
  *
  * // (int _0, long long _1, const char * _2)
- * ML99_indexedParams(ML99_list(v(int, long long, const char *)))
+ * ML99_indexedParams(ML99_list(ML99_QUOTE(int, long long, const char *)))
  *
  * // (void)
  * ML99_indexedParams(ML99_nil())
@@ -257,7 +257,7 @@
  * #include <metalang99/gen.h>
  *
  * // int _0; long long _1; const char * _2;
- * ML99_indexedFields(ML99_list(v(int, long long, const char *)))
+ * ML99_indexedFields(ML99_list(ML99_QUOTE(int, long long, const char *)))
  *
  * // ML99_empty()
  * ML99_indexedFields(ML99_nil())
@@ -276,10 +276,10 @@
  * #include <metalang99/gen.h>
  *
  * // { _0, _1, _2 }
- * ML99_indexedInitializerList(v(3))
+ * ML99_indexedInitializerList(ML99_QUOTE(3))
  *
  * // { 0 }
- * ML99_indexedInitializerList(v(0))
+ * ML99_indexedInitializerList(ML99_QUOTE(0))
  * @endcode
  */
 #define ML99_indexedInitializerList(n) ML99_call(ML99_indexedInitializerList, n)
@@ -295,41 +295,41 @@
  * #include <metalang99/gen.h>
  *
  * // _0, _1, _2
- * ML99_indexedArgs(v(3))
+ * ML99_indexedArgs(ML99_QUOTE(3))
  *
  * // ML99_empty()
- * ML99_indexedArgs(v(0))
+ * ML99_indexedArgs(ML99_QUOTE(0))
  * @endcode
  */
 #define ML99_indexedArgs(n) ML99_call(ML99_indexedArgs, n)
 
 #ifndef DOXYGEN_IGNORE
 
-#define ML99_semicoloned_IMPL(...)                    v(__VA_ARGS__;)
-#define ML99_braced_IMPL(...)                         v({__VA_ARGS__})
-#define ML99_assign_IMPL(lhs, ...)                    v(lhs = __VA_ARGS__)
-#define ML99_assignStmt_IMPL(lhs, ...)                v(lhs = __VA_ARGS__;)
-#define ML99_assignInitializerList_IMPL(lhs, ...)     v(lhs = {__VA_ARGS__})
-#define ML99_assignInitializerListStmt_IMPL(lhs, ...) v(lhs = {__VA_ARGS__};)
-#define ML99_invoke_IMPL(f, ...)                      v(f(__VA_ARGS__))
-#define ML99_invokeStmt_IMPL(f, ...)                  v(f(__VA_ARGS__);)
-#define ML99_typedef_IMPL(ident, ...)                 v(typedef __VA_ARGS__ ident;)
-#define ML99_fnPtr_IMPL(ret_ty, name, ...)            v(ret_ty (*name)(__VA_ARGS__))
-#define ML99_fnPtrStmt_IMPL(ret_ty, name, ...)        v(ret_ty (*name)(__VA_ARGS__);)
+#define ML99_semicoloned_IMPL(...)                    ML99_QUOTE(__VA_ARGS__;)
+#define ML99_braced_IMPL(...)                         ML99_QUOTE({__VA_ARGS__})
+#define ML99_assign_IMPL(lhs, ...)                    ML99_QUOTE(lhs = __VA_ARGS__)
+#define ML99_assignStmt_IMPL(lhs, ...)                ML99_QUOTE(lhs = __VA_ARGS__;)
+#define ML99_assignInitializerList_IMPL(lhs, ...)     ML99_QUOTE(lhs = {__VA_ARGS__})
+#define ML99_assignInitializerListStmt_IMPL(lhs, ...) ML99_QUOTE(lhs = {__VA_ARGS__};)
+#define ML99_invoke_IMPL(f, ...)                      ML99_QUOTE(f(__VA_ARGS__))
+#define ML99_invokeStmt_IMPL(f, ...)                  ML99_QUOTE(f(__VA_ARGS__);)
+#define ML99_typedef_IMPL(ident, ...)                 ML99_QUOTE(typedef __VA_ARGS__ ident;)
+#define ML99_fnPtr_IMPL(ret_ty, name, ...)            ML99_QUOTE(ret_ty (*name)(__VA_ARGS__))
+#define ML99_fnPtrStmt_IMPL(ret_ty, name, ...)        ML99_QUOTE(ret_ty (*name)(__VA_ARGS__);)
 
 // clang-format off
-#define ML99_prefixedBlock_IMPL(prefix, ...) v(prefix {__VA_ARGS__})
-#define ML99_struct_IMPL(ident, ...) v(struct ident {__VA_ARGS__})
-#define ML99_anonStruct_IMPL(...) v(struct {__VA_ARGS__})
-#define ML99_union_IMPL(ident, ...) v(union ident {__VA_ARGS__})
-#define ML99_anonUnion_IMPL(...) v(union {__VA_ARGS__})
-#define ML99_enum_IMPL(ident, ...) v(enum ident {__VA_ARGS__})
-#define ML99_anonEnum_IMPL(...) v(enum {__VA_ARGS__})
+#define ML99_prefixedBlock_IMPL(prefix, ...) ML99_QUOTE(prefix {__VA_ARGS__})
+#define ML99_struct_IMPL(ident, ...) ML99_QUOTE(struct ident {__VA_ARGS__})
+#define ML99_anonStruct_IMPL(...) ML99_QUOTE(struct {__VA_ARGS__})
+#define ML99_union_IMPL(ident, ...) ML99_QUOTE(union ident {__VA_ARGS__})
+#define ML99_anonUnion_IMPL(...) ML99_QUOTE(union {__VA_ARGS__})
+#define ML99_enum_IMPL(ident, ...) ML99_QUOTE(enum ident {__VA_ARGS__})
+#define ML99_anonEnum_IMPL(...) ML99_QUOTE(enum {__VA_ARGS__})
 // clang-format on
 
 #define ML99_times_IMPL(n, ...)        ML99_natMatchWithArgs_IMPL(n, ML99_PRIV_times_, __VA_ARGS__)
 #define ML99_PRIV_times_Z_IMPL         ML99_empty_IMPL
-#define ML99_PRIV_times_S_IMPL(i, ...) ML99_TERMS(v(__VA_ARGS__), ML99_times_IMPL(i, __VA_ARGS__))
+#define ML99_PRIV_times_S_IMPL(i, ...) ML99_TERMS(ML99_QUOTE(__VA_ARGS__), ML99_times_IMPL(i, __VA_ARGS__))
 
 #define ML99_repeat_IMPL(n, f)        ML99_natMatchWithArgs_IMPL(n, ML99_PRIV_repeat_, f)
 #define ML99_PRIV_repeat_Z_IMPL       ML99_empty_IMPL
@@ -340,14 +340,14 @@
 #define ML99_indexedParams_IMPL(type_list)                                                         \
     ML99_tuple(ML99_PRIV_IF(                                                                       \
         ML99_IS_NIL(type_list),                                                                    \
-        v(void),                                                                                   \
+        ML99_QUOTE(void),                                                                                   \
         ML99_variadicsTail(ML99_PRIV_indexedParamsAux_IMPL(type_list, 0))))
 
 #define ML99_PRIV_indexedParamsAux_IMPL(type_list, i)                                              \
     ML99_matchWithArgs_IMPL(type_list, ML99_PRIV_indexedParams_, i)
 #define ML99_PRIV_indexedParams_nil_IMPL ML99_empty_IMPL
 #define ML99_PRIV_indexedParams_cons_IMPL(x, xs, i)                                                \
-    ML99_TERMS(v(, x _##i), ML99_PRIV_indexedParamsAux_IMPL(xs, ML99_INC(i)))
+    ML99_TERMS(ML99_QUOTE(, x _##i), ML99_PRIV_indexedParamsAux_IMPL(xs, ML99_INC(i)))
 // } (ML99_indexedParams_IMPL)
 
 // ML99_indexedFields_IMPL {
@@ -358,11 +358,11 @@
     ML99_matchWithArgs_IMPL(type_list, ML99_PRIV_indexedFields_, i)
 #define ML99_PRIV_indexedFields_nil_IMPL ML99_empty_IMPL
 #define ML99_PRIV_indexedFields_cons_IMPL(x, xs, i)                                                \
-    ML99_TERMS(v(x _##i;), ML99_PRIV_indexedFieldsAux_IMPL(xs, ML99_INC(i)))
+    ML99_TERMS(ML99_QUOTE(x _##i;), ML99_PRIV_indexedFieldsAux_IMPL(xs, ML99_INC(i)))
 // } (ML99_indexedFields_IMPL)
 
-#define ML99_indexedInitializerList_IMPL(n) ML99_braced(ML99_PRIV_INDEXED_ITEMS(n, v(0)))
-#define ML99_indexedArgs_IMPL(n)            ML99_PRIV_INDEXED_ITEMS(n, v(ML99_EMPTY()))
+#define ML99_indexedInitializerList_IMPL(n) ML99_braced(ML99_PRIV_INDEXED_ITEMS(n, ML99_QUOTE(0)))
+#define ML99_indexedArgs_IMPL(n)            ML99_PRIV_INDEXED_ITEMS(n, ML99_QUOTE(ML99_EMPTY()))
 
 #define ML99_PRIV_INDEXED_ITEMS(n, empty_case)                                                     \
     ML99_PRIV_IF(                                                                                  \
@@ -370,7 +370,7 @@
         empty_case,                                                                                \
         ML99_variadicsTail(ML99_repeat_IMPL(n, ML99_PRIV_indexedItem)))
 
-#define ML99_PRIV_indexedItem_IMPL(i) v(, _##i)
+#define ML99_PRIV_indexedItem_IMPL(i) ML99_QUOTE(, _##i)
 
 // Arity specifiers {
 

--- a/include/metalang99/ident.h
+++ b/include/metalang99/ident.h
@@ -42,16 +42,16 @@
  * #define FOO_y ()
  *
  * // 1
- * ML99_detectIdent(v(FOO_), v(x))
+ * ML99_detectIdent(ML99_QUOTE(FOO_), ML99_QUOTE(x))
  *
  * // 1
- * ML99_detectIdent(v(FOO_), v(y))
+ * ML99_detectIdent(ML99_QUOTE(FOO_), ML99_QUOTE(y))
  *
  * // 0
- * ML99_detectIdent(v(FOO_), v(z))
+ * ML99_detectIdent(ML99_QUOTE(FOO_), ML99_QUOTE(z))
  *
  * // 1
- * ML99_detectIdent(v(ML99_UNDERSCORE_DETECTOR), v(_))
+ * ML99_detectIdent(ML99_QUOTE(ML99_UNDERSCORE_DETECTOR), ML99_QUOTE(_))
  * @endcode
  */
 #define ML99_detectIdent(prefix, ident) ML99_call(ML99_detectIdent, prefix, ident)
@@ -59,7 +59,7 @@
 /**
  * Compares two identifiers @p x and @p y for equality.
  *
- * This macro is a shortcut to `ML99_detectIdent(ML99_cat3(prefix, x, v(_)), y)`.
+ * This macro is a shortcut to `ML99_detectIdent(ML99_cat3(prefix, x, ML99_QUOTE(_)), y)`.
  *
  * # Predefined detectors
  *
@@ -78,19 +78,19 @@
  * #define FOO_y_y ()
  *
  * // 1
- * ML99_identEq(v(FOO_), v(x), v(x))
+ * ML99_identEq(ML99_QUOTE(FOO_), ML99_QUOTE(x), ML99_QUOTE(x))
  *
  * // 1
- * ML99_identEq(v(FOO_), v(y), v(y))
+ * ML99_identEq(ML99_QUOTE(FOO_), ML99_QUOTE(y), ML99_QUOTE(y))
  *
  * // 0
- * ML99_identEq(v(FOO_), v(x), v(y))
+ * ML99_identEq(ML99_QUOTE(FOO_), ML99_QUOTE(x), ML99_QUOTE(y))
  *
  * // 1
- * ML99_identEq(v(ML99_C_KEYWORD_DETECTOR), v(while), v(while))
- * ML99_identEq(v(ML99_LOWERCASE_DETECTOR), v(x), v(x))
- * ML99_identEq(v(ML99_UPPERCASE_DETECTOR), v(X), v(X))
- * ML99_identEq(v(ML99_DIGIT_DETECTOR), v(5), v(5))
+ * ML99_identEq(ML99_QUOTE(ML99_C_KEYWORD_DETECTOR), ML99_QUOTE(while), ML99_QUOTE(while))
+ * ML99_identEq(ML99_QUOTE(ML99_LOWERCASE_DETECTOR), ML99_QUOTE(x), ML99_QUOTE(x))
+ * ML99_identEq(ML99_QUOTE(ML99_UPPERCASE_DETECTOR), ML99_QUOTE(X), ML99_QUOTE(X))
+ * ML99_identEq(ML99_QUOTE(ML99_DIGIT_DETECTOR), ML99_QUOTE(5), ML99_QUOTE(5))
  * @endcode
  */
 #define ML99_identEq(prefix, x, y) ML99_call(ML99_identEq, prefix, x, y)
@@ -106,13 +106,13 @@
  * #include <metalang99/ident.h>
  *
  * // 1
- * ML99_charEq(v(t), v(t))
+ * ML99_charEq(ML99_QUOTE(t), ML99_QUOTE(t))
  *
  * // 0
- * ML99_charEq(v(9), v(A))
+ * ML99_charEq(ML99_QUOTE(9), ML99_QUOTE(A))
  *
  * // 0
- * ML99_charEq(v(9), v(abcd))
+ * ML99_charEq(ML99_QUOTE(9), ML99_QUOTE(abcd))
  * @endcode
  */
 #define ML99_charEq(x, y) ML99_call(ML99_charEq, x, y)
@@ -146,13 +146,13 @@
  * #include <metalang/ident.h>
  *
  * // 't'
- * ML99_charLit(v(t))
+ * ML99_charLit(ML99_QUOTE(t))
  *
  * // '9'
- * ML99_charLit(v(9))
+ * ML99_charLit(ML99_QUOTE(9))
  *
  * // '_'
- * ML99_charLit(v(_))
+ * ML99_charLit(ML99_QUOTE(_))
  * @endcode
  *
  * @note The inverse of this function is impossible, i.e., you cannot get `q` from `'q'`.
@@ -170,11 +170,11 @@
  * #include <metalang99/ident.h>
  * #include <metalang99/variadics.h>
  *
- * #define F_IMPL(x) v([x])
+ * #define F_IMPL(x) ML99_QUOTE([x])
  * #define F_ARITY   1
  *
  * // [a] [b] [c] ... [x] [y] [z]
- * ML99_variadicsForEach(v(F), v(ML99_LOWERCASE_CHARS()))
+ * ML99_variadicsForEach(ML99_QUOTE(F), ML99_QUOTE(ML99_LOWERCASE_CHARS()))
  * @endcode
  */
 #define ML99_LOWERCASE_CHARS(...)                                                                  \
@@ -218,14 +218,14 @@
 
 #ifndef DOXYGEN_IGNORE
 
-#define ML99_detectIdent_IMPL(prefix, ident) v(ML99_DETECT_IDENT(prefix, ident))
-#define ML99_identEq_IMPL(prefix, x, y)      v(ML99_IDENT_EQ(prefix, x, y))
-#define ML99_charEq_IMPL(x, y)               v(ML99_CHAR_EQ(x, y))
-#define ML99_isLowercase_IMPL(x)             v(ML99_IS_LOWERCASE(x))
-#define ML99_isUppercase_IMPL(x)             v(ML99_IS_UPPERCASE(x))
-#define ML99_isDigit_IMPL(x)                 v(ML99_IS_DIGIT(x))
-#define ML99_isChar_IMPL(x)                  v(ML99_IS_CHAR(x))
-#define ML99_charLit_IMPL(x)                 v(ML99_CHAR_LIT(x))
+#define ML99_detectIdent_IMPL(prefix, ident) ML99_QUOTE(ML99_DETECT_IDENT(prefix, ident))
+#define ML99_identEq_IMPL(prefix, x, y)      ML99_QUOTE(ML99_IDENT_EQ(prefix, x, y))
+#define ML99_charEq_IMPL(x, y)               ML99_QUOTE(ML99_CHAR_EQ(x, y))
+#define ML99_isLowercase_IMPL(x)             ML99_QUOTE(ML99_IS_LOWERCASE(x))
+#define ML99_isUppercase_IMPL(x)             ML99_QUOTE(ML99_IS_UPPERCASE(x))
+#define ML99_isDigit_IMPL(x)                 ML99_QUOTE(ML99_IS_DIGIT(x))
+#define ML99_isChar_IMPL(x)                  ML99_QUOTE(ML99_IS_CHAR(x))
+#define ML99_charLit_IMPL(x)                 ML99_QUOTE(ML99_CHAR_LIT(x))
 
 #define ML99_UNDERSCORE_DETECTOR ML99_PRIV_UNDERSCORE_DETECTOR_
 #define ML99_C_KEYWORD_DETECTOR  ML99_PRIV_C_KEYWORD_DETECTOR_

--- a/include/metalang99/lang.h
+++ b/include/metalang99/lang.h
@@ -141,8 +141,30 @@
 
 /**
  * A value that is pasted as-is; no evaluation occurs on provided arguments.
+ *
+ * # Examples
+ *
+ * @code
+ * #include <metalang99/lang.h>
+ *
+ * #define F_IMPL(x) ML99_QUOTE(~x)
+ *
+ * #define PROG ML99_TERMS(ML99_QUOTE(1), ML99_QUOTE(2), ML99_call(F, ML99_QUOTE(7)))
+ *
+ * // The same as `PROG` pasted into a source file.
+ * ML99_EVAL(ML99_QUOTE(PROG))
+ * @endcode
  */
-#define v(...) (0v, __VA_ARGS__)
+#define ML99_QUOTE(...) (0v, __VA_ARGS__)
+
+#ifndef ML99_NO_SHORT_NAMES
+/**
+ * A short alias for #ML99_QUOTE.
+ *
+ * @note Can be disabled by defining ML99_NO_SHORT_NAMES.
+ */
+#define v(...) ML99_QUOTE(__VA_ARGS__)
+#endif
 
 // clang-format off
 /**
@@ -204,26 +226,6 @@
  * @endcode
  */
 #define ML99_TERMS(...) __VA_ARGS__
-
-/**
- * Delays evaluation for provided terms.
- *
- * `ML99_QUOTE(...)` is functionally equivalent to `v(...)`.
- *
- * # Examples
- *
- * @code
- * #include <metalang99/lang.h>
- *
- * #define F_IMPL(x) v(~x)
- *
- * #define PROG ML99_TERMS(v(1), v(2), ML99_call(F, v(7)))
- *
- * // The same as `PROG` pasted into a source file.
- * ML99_EVAL(ML99_QUOTE(PROG))
- * @endcode
- */
-#define ML99_QUOTE(...) v(__VA_ARGS__)
 
 #ifndef DOXYGEN_IGNORE
 

--- a/include/metalang99/lang.h
+++ b/include/metalang99/lang.h
@@ -20,9 +20,9 @@
  * @code
  * #include <metalang99/lang.h>
  *
- * #define F_IMPL(x, y) v(x + y)
+ * #define F_IMPL(x, y) ML99_QUOTE(x + y)
  *
- * ML99_EVAL(v(abc ~ 123), ML99_call(F, v(1, 2)))
+ * ML99_EVAL(ML99_QUOTE(abc ~ 123), ML99_call(F, ML99_QUOTE(1, 2)))
  * @endcode
  */
 #define ML99_EVAL(...) ML99_PRIV_EVAL(__VA_ARGS__)
@@ -36,7 +36,7 @@
 /**
  * Invokes a metafunction @p ident with unevaluated arguments.
  *
- * It is semantically the same as `ML99_call(ident, v(...))` but performs one less reduction
+ * It is semantically the same as `ML99_call(ident, ML99_QUOTE(...))` but performs one less reduction
  * steps.
  */
 #define ML99_callUneval(ident, ...) (0callUneval, ident, __VA_ARGS__)
@@ -80,11 +80,11 @@
  * @code
  * #include <metalang99/lang.h>
  *
- * #define F_IMPL(x, y) v(x##y)
+ * #define F_IMPL(x, y) ML99_QUOTE(x##y)
  * #define F_ARITY      2
  *
  * // ab
- * ML99_appl(ML99_appl(v(F), v(a)), v(b))
+ * ML99_appl(ML99_appl(ML99_QUOTE(F), ML99_QUOTE(a)), ML99_QUOTE(b))
  * @endcode
  *
  * @note Currently, the maximum arity is #ML99_NAT_MAX. However, some compilers might not support
@@ -100,11 +100,11 @@
  * @code
  * #include <metalang99/lang.h>
  *
- * #define F_IMPL(x, y) v(x##y)
+ * #define F_IMPL(x, y) ML99_QUOTE(x##y)
  * #define F_ARITY      2
  *
  * // ab
- * ML99_appl2(v(F), v(a), v(b))
+ * ML99_appl2(ML99_QUOTE(F), ML99_QUOTE(a), ML99_QUOTE(b))
  * @endcode
  */
 #define ML99_appl2(f, a, b) ML99_call(ML99_appl2, f, a, b)
@@ -127,14 +127,14 @@
  * @code
  * #include <metalang99/lang.h>
  *
- * #define F_IMPL(x) v((x + 1))
- * #define G_IMPL(x) v((x * 8))
+ * #define F_IMPL(x) ML99_QUOTE((x + 1))
+ * #define G_IMPL(x) ML99_QUOTE((x * 8))
  *
  * #define F_ARITY 1
  * #define G_ARITY 1
  *
  * // ((3 * 8) + 1)
- * ML99_appl(ML99_compose(v(F), v(G)), v(3))
+ * ML99_appl(ML99_compose(ML99_QUOTE(F), ML99_QUOTE(G)), ML99_QUOTE(3))
  * @endcode
  */
 #define ML99_compose(f, g) ML99_call(ML99_compose, f, g)
@@ -204,10 +204,10 @@
  * @code
  * #include <metalang99/lang.h>
  *
- * #define F_IMPL(x) v(~)
+ * #define F_IMPL(x) ML99_QUOTE(~)
  *
  * // 123
- * ML99_call(F, ML99_abort(v(123)))
+ * ML99_call(F, ML99_abort(ML99_QUOTE(123)))
  * @endcode
  */
 #define ML99_abort(...) (0abort, __VA_ARGS__)
@@ -222,7 +222,7 @@
  * @code
  * #include <metalang99/lang.h>
  *
- * #define F_IMPL(x) ML99_TERMS(v(1), v(x), v(2))
+ * #define F_IMPL(x) ML99_TERMS(ML99_QUOTE(1), ML99_QUOTE(x), ML99_QUOTE(2))
  * @endcode
  */
 #define ML99_TERMS(...) __VA_ARGS__
@@ -230,7 +230,7 @@
 #ifndef DOXYGEN_IGNORE
 
 #define ML99_compose_IMPL(f, g)         ML99_appl2_IMPL(ML99_PRIV_compose, f, g)
-#define ML99_PRIV_compose_IMPL(f, g, x) ML99_appl(v(f), ML99_appl_IMPL(g, x))
+#define ML99_PRIV_compose_IMPL(f, g, x) ML99_appl(ML99_QUOTE(f), ML99_appl_IMPL(g, x))
 
 // Arity specifiers {
 

--- a/include/metalang99/lang/closure.h
+++ b/include/metalang99/lang/closure.h
@@ -31,7 +31,7 @@
     ML99_PRIV_IF(                                                                                  \
         ML99_PRIV_NAT_EQ(f##_ARITY, 1),                                                            \
         ML99_callUneval(f, __VA_ARGS__),                                                           \
-        v((ML99_PRIV_DEC(f##_ARITY), f, __VA_ARGS__)))
+        ML99_QUOTE((ML99_PRIV_DEC(f##_ARITY), f, __VA_ARGS__)))
 
 #define ML99_PRIV_APPL_CLOSURE(closure, ...)                                                       \
     ML99_PRIV_APPL_CLOSURE_AUX(ML99_PRIV_EXPAND closure, __VA_ARGS__)
@@ -42,10 +42,10 @@
     ML99_PRIV_IF(                                                                                  \
         ML99_PRIV_NAT_EQ(arity, 1),                                                                \
         ML99_callUneval(f, __VA_ARGS__),                                                           \
-        v((ML99_PRIV_DEC(arity), f, __VA_ARGS__)))
+        ML99_QUOTE((ML99_PRIV_DEC(arity), f, __VA_ARGS__)))
 
-#define ML99_appl2_IMPL(f, a, b)       ML99_appl(ML99_appl_IMPL(f, a), v(b))
-#define ML99_appl3_IMPL(f, a, b, c)    ML99_appl(ML99_appl2_IMPL(f, a, b), v(c))
-#define ML99_appl4_IMPL(f, a, b, c, d) ML99_appl(ML99_appl3_IMPL(f, a, b, c), v(d))
+#define ML99_appl2_IMPL(f, a, b)       ML99_appl(ML99_appl_IMPL(f, a), ML99_QUOTE(b))
+#define ML99_appl3_IMPL(f, a, b, c)    ML99_appl(ML99_appl2_IMPL(f, a, b), ML99_QUOTE(c))
+#define ML99_appl4_IMPL(f, a, b, c, d) ML99_appl(ML99_appl3_IMPL(f, a, b, c), ML99_QUOTE(d))
 
 #endif // ML99_LANG_CLOSURE_H

--- a/include/metalang99/list.h
+++ b/include/metalang99/list.h
@@ -24,7 +24,7 @@
  * @code
  * #include <metalang99/list.h>
  *
- * ML99_cons(v(1), ML99_cons(v(2), ML99_nil()))
+ * ML99_cons(ML99_QUOTE(1), ML99_cons(ML99_QUOTE(2), ML99_nil()))
  * @endcode
  */
 #define ML99_cons(x, xs) ML99_call(ML99_cons, x, xs)
@@ -43,7 +43,7 @@
  * #include <metalang99/list.h>
  *
  * // 1
- * ML99_isCons(ML99_list(v(1, 2, 3)))
+ * ML99_isCons(ML99_list(ML99_QUOTE(1, 2, 3)))
  *
  * // 0
  * ML99_isCons(ML99_nil())
@@ -60,7 +60,7 @@
  * #include <metalang99/list.h>
  *
  * // 0
- * ML99_isNil(ML99_list(v(1, 2, 3)))
+ * ML99_isNil(ML99_list(ML99_QUOTE(1, 2, 3)))
  *
  * // 1
  * ML99_isNil(ML99_nil())
@@ -77,7 +77,7 @@
  * #include <metalang99/list.h>
  *
  * // 1
- * ML99_listHead(ML99_list(v(1, 2, 3)))
+ * ML99_listHead(ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listHead(list) ML99_call(ML99_listHead, list)
@@ -91,10 +91,10 @@
  * #include <metalang99/list.h>
  *
  * // 2, 3
- * ML99_listTail(ML99_list(v(1, 2, 3)))
+ * ML99_listTail(ML99_list(ML99_QUOTE(1, 2, 3)))
  *
  * // ML99_nil()
- * ML99_listTail(ML99_list(v(1)))
+ * ML99_listTail(ML99_list(ML99_QUOTE(1)))
  * @endcode
  */
 #define ML99_listTail(list) ML99_call(ML99_listTail, list)
@@ -108,7 +108,7 @@
  * #include <metalang99/list.h>
  *
  * // 3
- * ML99_listLast(ML99_list(v(1, 2, 3)))
+ * ML99_listLast(ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listLast(list) ML99_call(ML99_listLast, list)
@@ -122,10 +122,10 @@
  * #include <metalang99/list.h>
  *
  * // 1, 2
- * ML99_listInit(ML99_list(v(1, 2, 3)))
+ * ML99_listInit(ML99_list(ML99_QUOTE(1, 2, 3)))
  *
  * // ML99_nil()
- * ML99_listInit(ML99_list(v(1)))
+ * ML99_listInit(ML99_list(ML99_QUOTE(1)))
  * @endcode
  */
 #define ML99_listInit(list) ML99_call(ML99_listInit, list)
@@ -141,7 +141,7 @@
  * #include <metalang99/list.h>
  *
  * // 1, 2, 3
- * ML99_list(v(1, 2, 3))
+ * ML99_list(ML99_QUOTE(1, 2, 3))
  * @endcode
  */
 #define ML99_list(...) ML99_call(ML99_list, __VA_ARGS__)
@@ -161,11 +161,11 @@
  * @code
  * #include <metalang99/list.h>
  *
- * #define F_IMPL(x, y) v(x + y)
+ * #define F_IMPL(x, y) ML99_QUOTE(x + y)
  * #define F_ARITY      1
  *
- * // ML99_list(v(1 + 2, 3 + 4, 5 + 6))
- * ML99_listFromTuples(v(F), v((1, 2), (3, 4), (5, 6)))
+ * // ML99_list(ML99_QUOTE(1 + 2, 3 + 4, 5 + 6))
+ * ML99_listFromTuples(ML99_QUOTE(F), ML99_QUOTE((1, 2), (3, 4), (5, 6)))
  * @endcode
  */
 #define ML99_listFromTuples(f, ...) ML99_call(ML99_listFromTuples, f, __VA_ARGS__)
@@ -182,10 +182,10 @@
  * #include <metalang99/list.h>
  *
  * // ML99_nil()
- * ML99_listFromSeq(v())
+ * ML99_listFromSeq(ML99_QUOTE())
  *
- * // ML99_list(v(1, 2, 3))
- * ML99_listFromSeq(v((1)(2)(3)))
+ * // ML99_list(ML99_QUOTE(1, 2, 3))
+ * ML99_listFromSeq(ML99_QUOTE((1)(2)(3)))
  * @endcode
  */
 #define ML99_listFromSeq(seq) ML99_call(ML99_listFromSeq, seq)
@@ -202,7 +202,7 @@
  * ML99_listLen(ML99_nil())
  *
  * // 3
- * ML99_listLen(ML99_list(v(1, 2, 3)))
+ * ML99_listLen(ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listLen(list) ML99_call(ML99_listLen, list)
@@ -218,7 +218,7 @@
  * #include <metalang99/list.h>
  *
  * // Literally 1 2 3
- * ML99_LIST_EVAL(ML99_list(v(1, 2, 3)))
+ * ML99_LIST_EVAL(ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  *
  * @note This macro does not result in a Metalang99 term; it literally pastes list elements into a
@@ -235,7 +235,7 @@
  * #include <metalang99/util.h>
  *
  * // Literally 1, 2, 3
- * ML99_LIST_EVAL_COMMA_SEP(ML99_list(v(1, 2, 3)))
+ * ML99_LIST_EVAL_COMMA_SEP(ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  *
  * @note This macro does not result in a Metalang99 term; it literally pastes comma-separated list
@@ -252,7 +252,7 @@
  * #include <metalang99/list.h>
  *
  * // 1, 2, 3
- * ML99_listAppend(ML99_list(v(1)), ML99_list(v(2, 3)))
+ * ML99_listAppend(ML99_list(ML99_QUOTE(1)), ML99_list(ML99_QUOTE(2, 3)))
  * @endcode
  */
 #define ML99_listAppend(list, other) ML99_call(ML99_listAppend, list, other)
@@ -266,7 +266,7 @@
  * #include <metalang99/list.h>
  *
  * // 1, 2, 3
- * ML99_listAppendItem(v(3), ML99_list(v(1, 2)))
+ * ML99_listAppendItem(ML99_QUOTE(3), ML99_list(ML99_QUOTE(1, 2)))
  * @endcode
  */
 #define ML99_listAppendItem(item, list) ML99_call(ML99_listAppendItem, item, list)
@@ -280,7 +280,7 @@
  * #include <metalang99/list.h>
  *
  * // Literally 1 2 3
- * ML99_listUnwrap(ML99_list(v(1, 2, 3)))
+ * ML99_listUnwrap(ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  *
  * @note The resulting value is still a valid Metalang99 term that need to be evaluated further.
@@ -298,7 +298,7 @@
  * #include <metalang99/list.h>
  *
  * // Literally 1, 2, 3
- * ML99_listUnwrapCommaSep(ML99_list(v(1, 2, 3)))
+ * ML99_listUnwrapCommaSep(ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  *
  * @note The resulting value is still a valid Metalang99 term that need to be evaluated further.
@@ -316,7 +316,7 @@
  * #include <metalang99/list.h>
  *
  * // 3, 2, 1
- * ML99_listReverse(ML99_list(v(1, 2, 3)))
+ * ML99_listReverse(ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listReverse(list) ML99_call(ML99_listReverse, list)
@@ -330,7 +330,7 @@
  * #include <metalang99/list.h>
  *
  * // 2
- * ML99_listGet(v(1), ML99_list(v(1, 2, 3)))
+ * ML99_listGet(ML99_QUOTE(1), ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listGet(i, list) ML99_call(ML99_listGet, i, list)
@@ -346,10 +346,10 @@
  * #define ABCDEFG 123
  *
  * // 7
- * ML99_listFoldr(v(ML99_cat), v(7), ML99_nil())
+ * ML99_listFoldr(ML99_QUOTE(ML99_cat), ML99_QUOTE(7), ML99_nil())
  *
  * // 123
- * ML99_listFoldr(ML99_appl(v(ML99_flip), v(ML99_cat)), v(A), ML99_list(v(G, DEF, BC)))
+ * ML99_listFoldr(ML99_appl(ML99_QUOTE(ML99_flip), ML99_QUOTE(ML99_cat)), ML99_QUOTE(A), ML99_list(ML99_QUOTE(G, DEF, BC)))
  * @endcode
  */
 #define ML99_listFoldr(f, init, list) ML99_call(ML99_listFoldr, f, init, list)
@@ -365,10 +365,10 @@
  * #define ABCDEFG 123
  *
  * // 7
- * ML99_listFoldl(v(ML99_cat), v(7), ML99_nil())
+ * ML99_listFoldl(ML99_QUOTE(ML99_cat), ML99_QUOTE(7), ML99_nil())
  *
  * // 123
- * ML99_listFoldl(v(ML99_cat), v(A), ML99_list(v(BC, DEF, G)))
+ * ML99_listFoldl(ML99_QUOTE(ML99_cat), ML99_QUOTE(A), ML99_list(ML99_QUOTE(BC, DEF, G)))
  * @endcode
  */
 #define ML99_listFoldl(f, init, list) ML99_call(ML99_listFoldl, f, init, list)
@@ -384,7 +384,7 @@
  * #define ABCDEFG 123
  *
  * // 123
- * ML99_listFoldl1(v(ML99_cat), ML99_list(v(AB, CDEF, G)))
+ * ML99_listFoldl1(ML99_QUOTE(ML99_cat), ML99_list(ML99_QUOTE(AB, CDEF, G)))
  * @endcode
  */
 #define ML99_listFoldl1(f, list) ML99_call(ML99_listFoldl1, f, list)
@@ -398,7 +398,7 @@
  * #include <metalang99/list.h>
  *
  * // 1, +, 2, +, 3
- * ML99_listIntersperse(v(+), ML99_list(v(1, 2, 3)))
+ * ML99_listIntersperse(ML99_QUOTE(+), ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listIntersperse(item, list) ML99_call(ML99_listIntersperse, item, list)
@@ -412,7 +412,7 @@
  * #include <metalang99/list.h>
  *
  * // +, 1, +, 2, +, 3
- * ML99_listPrependToAll(v(+), ML99_list(v(1, 2, 3)))
+ * ML99_listPrependToAll(ML99_QUOTE(+), ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listPrependToAll(item, list) ML99_call(ML99_listPrependToAll, item, list)
@@ -427,7 +427,7 @@
  * #include <metalang99/nat.h>
  *
  * // 4, 5, 6
- * ML99_listMap(ML99_appl(v(ML99_add), v(3)), ML99_list(v(1, 2, 3)))
+ * ML99_listMap(ML99_appl(ML99_QUOTE(ML99_add), ML99_QUOTE(3)), ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listMap(f, list) ML99_call(ML99_listMap, f, list)
@@ -440,11 +440,11 @@
  * @code
  * #include <metalang99/list.h>
  *
- * #define F_IMPL(x, i) v(x[i])
+ * #define F_IMPL(x, i) ML99_QUOTE(x[i])
  * #define F_ARITY      2
  *
  * // a[0], b[1], c[2]
- * ML99_listMapI(v(F), ML99_list(v(a, b, c)))
+ * ML99_listMapI(ML99_QUOTE(F), ML99_list(ML99_QUOTE(a, b, c)))
  * @endcode
  */
 #define ML99_listMapI(f, list) ML99_call(ML99_listMapI, f, list)
@@ -473,7 +473,7 @@
  * #include <metalang99/nat.h>
  *
  * // 4, 5, 6
- * ML99_listFor(ML99_list(v(1, 2, 3)), ML99_appl(v(ML99_add), v(3)))
+ * ML99_listFor(ML99_list(ML99_QUOTE(1, 2, 3)), ML99_appl(ML99_QUOTE(ML99_add), ML99_QUOTE(3)))
  * @endcode
  */
 #define ML99_listFor(list, f) ML99_call(ML99_listFor, list, f)
@@ -486,7 +486,7 @@
  *
  * @code
  * // 4, 5, 10
- * ML99_listMapInitLast(ML99_appl(v(ML99_add), v(3)), ML99_appl(v(ML99_add), v(7)), ML99_list(v(1,
+ * ML99_listMapInitLast(ML99_appl(ML99_QUOTE(ML99_add), ML99_QUOTE(3)), ML99_appl(ML99_QUOTE(ML99_add), ML99_QUOTE(7)), ML99_list(ML99_QUOTE(1,
  * 2, 3)))
  * @endcode
  */
@@ -500,8 +500,8 @@
  *
  * @code
  * // 4, 5, 10
- * ML99_listForInitLast(ML99_list(v(1, 2, 3)), ML99_appl(v(ML99_add), v(3)), ML99_appl(v(ML99_add),
- * v(7)))
+ * ML99_listForInitLast(ML99_list(ML99_QUOTE(1, 2, 3)), ML99_appl(ML99_QUOTE(ML99_add), ML99_QUOTE(3)), ML99_appl(ML99_QUOTE(ML99_add),
+ * ML99_QUOTE(7)))
  * @endcode
  */
 #define ML99_listForInitLast(list, f_init, f_last)                                                 \
@@ -517,7 +517,7 @@
  * #include <metalang99/nat.h>
  *
  * // 9, 11, 6
- * ML99_listFilter(ML99_appl(v(ML99_lesser), v(5)), ML99_list(v(9, 1, 11, 6, 0, 4)))
+ * ML99_listFilter(ML99_appl(ML99_QUOTE(ML99_lesser), ML99_QUOTE(5)), ML99_list(ML99_QUOTE(9, 1, 11, 6, 0, 4)))
  * @endcode
  */
 #define ML99_listFilter(f, list) ML99_call(ML99_listFilter, f, list)
@@ -534,10 +534,10 @@
  * #include <metalang99/list.h>
  * #include <metalang99/maybe.h>
  *
- * #define MAYBE_LIST ML99_list(ML99_just(v(5)), ML99_nothing(), ML99_just(v(7)))
+ * #define MAYBE_LIST ML99_list(ML99_just(ML99_QUOTE(5)), ML99_nothing(), ML99_just(ML99_QUOTE(7)))
  *
  * // 5, 7
- * ML99_listFilterMap(v(ML99_id), MAYBE_LIST)
+ * ML99_listFilterMap(ML99_QUOTE(ML99_id), MAYBE_LIST)
  * @endcode
  */
 #define ML99_listFilterMap(f, list) ML99_call(ML99_listFilterMap, f, list)
@@ -552,10 +552,10 @@
  * #include <metalang99/nat.h>
  *
  * // 0
- * ML99_listEq(v(ML99_natEq), ML99_list(v(1, 2, 3)), ML99_list(v(4, 5, 6)))
+ * ML99_listEq(ML99_QUOTE(ML99_natEq), ML99_list(ML99_QUOTE(1, 2, 3)), ML99_list(ML99_QUOTE(4, 5, 6)))
  *
  * // 1
- * ML99_listEq(v(ML99_natEq), ML99_list(v(1, 2, 3)), ML99_list(v(1, 2, 3)))
+ * ML99_listEq(ML99_QUOTE(ML99_natEq), ML99_list(ML99_QUOTE(1, 2, 3)), ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listEq(cmp, list, other) ML99_call(ML99_listEq, cmp, list, other)
@@ -570,10 +570,10 @@
  * #include <metalang99/nat.h>
  *
  * // 1
- * ML99_listContains(v(ML99_natEq), v(3), ML99_list(v(1, 2, 3)))
+ * ML99_listContains(ML99_QUOTE(ML99_natEq), ML99_QUOTE(3), ML99_list(ML99_QUOTE(1, 2, 3)))
  *
  * // 0
- * ML99_listContains(v(ML99_natEq), v(456), ML99_list(v(1, 2, 3)))
+ * ML99_listContains(ML99_QUOTE(ML99_natEq), ML99_QUOTE(456), ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listContains(cmp, item, list) ML99_call(ML99_listContains, cmp, item, list)
@@ -588,7 +588,7 @@
  * #include <metalang99/list.h>
  *
  * // 1, 2
- * ML99_listTake(v(2), ML99_list(v(1, 2, 3)))
+ * ML99_listTake(ML99_QUOTE(2), ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listTake(n, list) ML99_call(ML99_listTake, n, list)
@@ -603,7 +603,7 @@
  * #include <metalang99/nat.h>
  *
  * // 1, 2, 3
- * ML99_listTakeWhile(ML99_appl(v(ML99_greater), v(4)), ML99_list(v(1, 2, 3, 4, 5, 6)))
+ * ML99_listTakeWhile(ML99_appl(ML99_QUOTE(ML99_greater), ML99_QUOTE(4)), ML99_list(ML99_QUOTE(1, 2, 3, 4, 5, 6)))
  * @endcode
  */
 #define ML99_listTakeWhile(f, list) ML99_call(ML99_listTakeWhile, f, list)
@@ -618,7 +618,7 @@
  * #include <metalang99/list.h>
  *
  * // 2, 3
- * ML99_listDrop(v(1), ML99_list(v(1, 2, 3)))
+ * ML99_listDrop(ML99_QUOTE(1), ML99_list(ML99_QUOTE(1, 2, 3)))
  * @endcode
  */
 #define ML99_listDrop(n, list) ML99_call(ML99_listDrop, n, list)
@@ -633,7 +633,7 @@
  * #include <metalang99/nat.h>
  *
  * // 4, 5, 6
- * ML99_listDropWhile(ML99_appl(v(ML99_lesser), v(4)), ML99_list(v(1, 2, 3, 4, 5, 6)))
+ * ML99_listDropWhile(ML99_appl(ML99_QUOTE(ML99_lesser), ML99_QUOTE(4)), ML99_list(ML99_QUOTE(1, 2, 3, 4, 5, 6)))
  * @endcode
  */
 #define ML99_listDropWhile(f, list) ML99_call(ML99_listDropWhile, f, list)
@@ -647,7 +647,7 @@
  * #include <metalang99/list.h>
  *
  * // (1, 4), (2, 5), (3, 6)
- * ML99_listZip(ML99_list(v(1, 2, 3)), ML99_list(v(4, 5, 6)))
+ * ML99_listZip(ML99_list(ML99_QUOTE(1, 2, 3)), ML99_list(ML99_QUOTE(4, 5, 6)))
  * @endcode
  */
 #define ML99_listZip(list, other) ML99_call(ML99_listZip, list, other)
@@ -662,8 +662,8 @@
  * #include <metalang99/list.h>
  * #include <metalang99/tuple.h>
  *
- * // ML99_tuple(ML99_list(v(1, 2, 3)), ML99_list(v(4, 5, 6)))
- * ML99_listUnzip(ML99_list(ML99_tuple(v(1, 4)), ML99_tuple(v(2, 5)), ML99_tuple(v(3, 6))))
+ * // ML99_tuple(ML99_list(ML99_QUOTE(1, 2, 3)), ML99_list(ML99_QUOTE(4, 5, 6)))
+ * ML99_listUnzip(ML99_list(ML99_tuple(ML99_QUOTE(1, 4)), ML99_tuple(ML99_QUOTE(2, 5)), ML99_tuple(ML99_QUOTE(3, 6))))
  * @endcode
  */
 #define ML99_listUnzip(list) ML99_call(ML99_listUnzip, list)
@@ -677,10 +677,10 @@
  * #include <metalang99/list.h>
  *
  * // ~, ~, ~, ~, ~
- * ML99_listReplicate(v(5), v(~))
+ * ML99_listReplicate(ML99_QUOTE(5), ML99_QUOTE(~))
  *
  * // ML99_nil()
- * ML99_listReplicate(v(0), v(~))
+ * ML99_listReplicate(ML99_QUOTE(0), ML99_QUOTE(~))
  * @endcode
  */
 #define ML99_listReplicate(n, item) ML99_call(ML99_listReplicate, n, item)
@@ -695,8 +695,8 @@
  * #include <metalang99/list.h>
  * #include <metalang99/nat.h>
  *
- * // ML99_tuple(ML99_list(v(4, 7)), ML99_list(v(11, 12, 13)))
- * ML99_listPartition(ML99_appl(v(ML99_greater), v(10)), ML99_list(v(11, 4, 12, 13, 7)))
+ * // ML99_tuple(ML99_list(ML99_QUOTE(4, 7)), ML99_list(ML99_QUOTE(11, 12, 13)))
+ * ML99_listPartition(ML99_appl(ML99_QUOTE(ML99_greater), ML99_QUOTE(10)), ML99_list(ML99_QUOTE(11, 4, 12, 13, 7)))
  * @endcode
  */
 #define ML99_listPartition(f, list) ML99_call(ML99_listPartition, f, list)
@@ -713,13 +713,13 @@
  * #include <metalang99/nat.h>
  *
  * // ML99_add
- * ML99_listAppl(v(ML99_add), ML99_nil())
+ * ML99_listAppl(ML99_QUOTE(ML99_add), ML99_nil())
  *
- * // ML99_appl(v(ML99_add), v(1))
- * ML99_listAppl(v(ML99_add), ML99_list(v(1)))
+ * // ML99_appl(ML99_QUOTE(ML99_add), ML99_QUOTE(1))
+ * ML99_listAppl(ML99_QUOTE(ML99_add), ML99_list(ML99_QUOTE(1)))
  *
- * // ML99_appl2(v(ML99_add), v(1), v(2))
- * ML99_listAppl(v(ML99_add), ML99_list(v(1, 2)))
+ * // ML99_appl2(ML99_QUOTE(ML99_add), ML99_QUOTE(1), ML99_QUOTE(2))
+ * ML99_listAppl(ML99_QUOTE(ML99_add), ML99_list(ML99_QUOTE(1, 2)))
  * @endcode
  */
 #define ML99_listAppl(f, list) ML99_call(ML99_listAppl, f, list)
@@ -731,29 +731,29 @@
 
 #ifndef DOXYGEN_IGNORE
 
-#define ML99_cons_IMPL(x, xs) v(ML99_CONS(x, xs))
-#define ML99_nil_IMPL(...)    v(ML99_NIL())
+#define ML99_cons_IMPL(x, xs) ML99_QUOTE(ML99_CONS(x, xs))
+#define ML99_nil_IMPL(...)    ML99_QUOTE(ML99_NIL())
 
-#define ML99_isCons_IMPL(list) v(ML99_IS_CONS(list))
-#define ML99_isNil_IMPL(list)  v(ML99_IS_NIL(list))
+#define ML99_isCons_IMPL(list) ML99_QUOTE(ML99_IS_CONS(list))
+#define ML99_isNil_IMPL(list)  ML99_QUOTE(ML99_IS_NIL(list))
 
 #define ML99_listHead_IMPL(list)             ML99_match_IMPL(list, ML99_PRIV_listHead_)
 #define ML99_PRIV_listHead_nil_IMPL(_)       ML99_PRIV_EMPTY_LIST_ERROR(listHead)
-#define ML99_PRIV_listHead_cons_IMPL(x, _xs) v(x)
+#define ML99_PRIV_listHead_cons_IMPL(x, _xs) ML99_QUOTE(x)
 
 #define ML99_listTail_IMPL(list)             ML99_match_IMPL(list, ML99_PRIV_listTail_)
 #define ML99_PRIV_listTail_nil_IMPL(_)       ML99_PRIV_EMPTY_LIST_ERROR(listTail)
-#define ML99_PRIV_listTail_cons_IMPL(_x, xs) v(xs)
+#define ML99_PRIV_listTail_cons_IMPL(_x, xs) ML99_QUOTE(xs)
 
 #define ML99_listLast_IMPL(list)       ML99_match_IMPL(list, ML99_PRIV_listLast_)
 #define ML99_PRIV_listLast_nil_IMPL(_) ML99_PRIV_EMPTY_LIST_ERROR(listLast)
 #define ML99_PRIV_listLast_cons_IMPL(x, xs)                                                        \
-    ML99_PRIV_IF(ML99_IS_NIL(xs), v(x), ML99_listLast_IMPL(xs))
+    ML99_PRIV_IF(ML99_IS_NIL(xs), ML99_QUOTE(x), ML99_listLast_IMPL(xs))
 
 #define ML99_listInit_IMPL(list)       ML99_match_IMPL(list, ML99_PRIV_listInit_)
 #define ML99_PRIV_listInit_nil_IMPL(_) ML99_PRIV_EMPTY_LIST_ERROR(listInit)
 #define ML99_PRIV_listInit_cons_IMPL(x, xs)                                                        \
-    ML99_PRIV_IF(ML99_IS_NIL(xs), v(ML99_NIL()), ML99_cons(v(x), ML99_listInit_IMPL(xs)))
+    ML99_PRIV_IF(ML99_IS_NIL(xs), ML99_QUOTE(ML99_NIL()), ML99_cons(ML99_QUOTE(x), ML99_listInit_IMPL(xs)))
 
 // ML99_list_IMPL {
 
@@ -781,15 +781,15 @@
     (count, __VA_ARGS__)
 
 #define ML99_PRIV_listProgressAux(count, x, ...)                                                   \
-    ML99_cons(v(x), ML99_callUneval(ML99_PRIV_listProgress, ML99_DEC(count), __VA_ARGS__))
+    ML99_cons(ML99_QUOTE(x), ML99_callUneval(ML99_PRIV_listProgress, ML99_DEC(count), __VA_ARGS__))
 
-#define ML99_PRIV_listDone_0(_count, _)       v(ML99_NIL())
-#define ML99_PRIV_listDone_1(_count, a, _)    v(ML99_CONS(a, ML99_NIL()))
-#define ML99_PRIV_listDone_2(_count, a, b, _) v(ML99_CONS(a, ML99_CONS(b, ML99_NIL())))
+#define ML99_PRIV_listDone_0(_count, _)       ML99_QUOTE(ML99_NIL())
+#define ML99_PRIV_listDone_1(_count, a, _)    ML99_QUOTE(ML99_CONS(a, ML99_NIL()))
+#define ML99_PRIV_listDone_2(_count, a, b, _) ML99_QUOTE(ML99_CONS(a, ML99_CONS(b, ML99_NIL())))
 #define ML99_PRIV_listDone_3(_count, a, b, c, _)                                                   \
-    v(ML99_CONS(a, ML99_CONS(b, ML99_CONS(c, ML99_NIL()))))
+    ML99_QUOTE(ML99_CONS(a, ML99_CONS(b, ML99_CONS(c, ML99_NIL()))))
 #define ML99_PRIV_listDone_4(_count, a, b, c, d, _)                                                \
-    v(ML99_CONS(a, ML99_CONS(b, ML99_CONS(c, ML99_CONS(d, ML99_NIL())))))
+    ML99_QUOTE(ML99_CONS(a, ML99_CONS(b, ML99_CONS(c, ML99_CONS(d, ML99_NIL())))))
 // } (ML99_list_IMPL)
 
 // ML99_listFromTuples_IMPL {
@@ -805,7 +805,7 @@
         ML99_appl_IMPL(f, ML99_UNTUPLE(x)),                                                        \
         ML99_PRIV_IF(                                                                              \
             ML99_VARIADICS_IS_SINGLE(__VA_ARGS__),                                                 \
-            v(ML99_NIL()),                                                                         \
+            ML99_QUOTE(ML99_NIL()),                                                                         \
             ML99_callUneval(ML99_PRIV_listFromTuplesAux, f, __VA_ARGS__)))
 // } (ML99_listFromTuples_IMPL)
 
@@ -813,44 +813,44 @@
     ML99_PRIV_CAT(ML99_PRIV_listFromSeq_, ML99_SEQ_IS_EMPTY(seq))(seq)
 #define ML99_PRIV_listFromSeq_1 ML99_nil_IMPL
 #define ML99_PRIV_listFromSeq_0(seq)                                                               \
-    ML99_cons(v(ML99_SEQ_GET(0)(seq)), ML99_callUneval(ML99_listFromSeq, ML99_SEQ_TAIL(seq)))
+    ML99_cons(ML99_QUOTE(ML99_SEQ_GET(0)(seq)), ML99_callUneval(ML99_listFromSeq, ML99_SEQ_TAIL(seq)))
 
 #define ML99_listLen_IMPL(list)             ML99_match_IMPL(list, ML99_PRIV_listLen_)
-#define ML99_PRIV_listLen_nil_IMPL(_)       v(0)
+#define ML99_PRIV_listLen_nil_IMPL(_)       ML99_QUOTE(0)
 #define ML99_PRIV_listLen_cons_IMPL(_x, xs) ML99_inc(ML99_listLen_IMPL(xs))
 
 #define ML99_listAppend_IMPL(list, other)                                                          \
     ML99_matchWithArgs_IMPL(list, ML99_PRIV_listAppend_, other)
-#define ML99_PRIV_listAppend_nil_IMPL(_, other) v(other)
+#define ML99_PRIV_listAppend_nil_IMPL(_, other) ML99_QUOTE(other)
 #define ML99_PRIV_listAppend_cons_IMPL(x, xs, other)                                               \
-    ML99_cons(v(x), ML99_listAppend_IMPL(xs, other))
+    ML99_cons(ML99_QUOTE(x), ML99_listAppend_IMPL(xs, other))
 
 #define ML99_listAppendItem_IMPL(item, list) ML99_listAppend_IMPL(list, ML99_CONS(item, ML99_NIL()))
 
 #define ML99_listUnwrap_IMPL(list)            ML99_match_IMPL(list, ML99_PRIV_listUnwrap_)
 #define ML99_PRIV_listUnwrap_nil_IMPL         ML99_empty_IMPL
-#define ML99_PRIV_listUnwrap_cons_IMPL(x, xs) ML99_TERMS(v(x), ML99_listUnwrap_IMPL(xs))
+#define ML99_PRIV_listUnwrap_cons_IMPL(x, xs) ML99_TERMS(ML99_QUOTE(x), ML99_listUnwrap_IMPL(xs))
 
 #define ML99_listReverse_IMPL(list)            ML99_match_IMPL(list, ML99_PRIV_listReverse_)
 #define ML99_PRIV_listReverse_nil_IMPL         ML99_nil_IMPL
-#define ML99_PRIV_listReverse_cons_IMPL(x, xs) ML99_listAppendItem(v(x), ML99_listReverse_IMPL(xs))
+#define ML99_PRIV_listReverse_cons_IMPL(x, xs) ML99_listAppendItem(ML99_QUOTE(x), ML99_listReverse_IMPL(xs))
 
 #define ML99_listGet_IMPL(i, list)       ML99_matchWithArgs_IMPL(list, ML99_PRIV_listGet_, i)
 #define ML99_PRIV_listGet_nil_IMPL(_, i) ML99_PRIV_EMPTY_LIST_ERROR(ML99_listGet)
 #define ML99_PRIV_listGet_cons_IMPL(x, xs, i)                                                      \
-    ML99_PRIV_IF(ML99_NAT_EQ(i, 0), v(x), ML99_listGet_IMPL(ML99_DEC(i), xs))
+    ML99_PRIV_IF(ML99_NAT_EQ(i, 0), ML99_QUOTE(x), ML99_listGet_IMPL(ML99_DEC(i), xs))
 
 #define ML99_listFoldr_IMPL(f, init, list)                                                         \
     ML99_matchWithArgs_IMPL(list, ML99_PRIV_listFoldr_, f, init)
-#define ML99_PRIV_listFoldr_nil_IMPL(_, _f, acc) v(acc)
+#define ML99_PRIV_listFoldr_nil_IMPL(_, _f, acc) ML99_QUOTE(acc)
 #define ML99_PRIV_listFoldr_cons_IMPL(x, xs, f, acc)                                               \
-    ML99_call(ML99_appl2, v(f, x), ML99_listFoldr_IMPL(f, acc, xs))
+    ML99_call(ML99_appl2, ML99_QUOTE(f, x), ML99_listFoldr_IMPL(f, acc, xs))
 
 #define ML99_listFoldl_IMPL(f, init, list)                                                         \
     ML99_matchWithArgs_IMPL(list, ML99_PRIV_listFoldl_, f, init)
-#define ML99_PRIV_listFoldl_nil_IMPL(_, _f, acc) v(acc)
+#define ML99_PRIV_listFoldl_nil_IMPL(_, _f, acc) ML99_QUOTE(acc)
 #define ML99_PRIV_listFoldl_cons_IMPL(x, xs, f, acc)                                               \
-    ML99_listFoldl(v(f), ML99_appl2_IMPL(f, acc, x), v(xs))
+    ML99_listFoldl(ML99_QUOTE(f), ML99_appl2_IMPL(f, acc, x), ML99_QUOTE(xs))
 
 #define ML99_listFoldl1_IMPL(f, list)            ML99_matchWithArgs_IMPL(list, ML99_PRIV_listFoldl1_, f)
 #define ML99_PRIV_listFoldl1_nil_IMPL(_, _f)     ML99_PRIV_EMPTY_LIST_ERROR(ML99_listFoldl1)
@@ -860,13 +860,13 @@
     ML99_matchWithArgs_IMPL(list, ML99_PRIV_listIntersperse_, item)
 #define ML99_PRIV_listIntersperse_nil_IMPL ML99_nil_IMPL
 #define ML99_PRIV_listIntersperse_cons_IMPL(x, xs, item)                                           \
-    ML99_cons(v(x), ML99_listPrependToAll_IMPL(item, xs))
+    ML99_cons(ML99_QUOTE(x), ML99_listPrependToAll_IMPL(item, xs))
 
 #define ML99_listPrependToAll_IMPL(item, list)                                                     \
     ML99_matchWithArgs_IMPL(list, ML99_PRIV_listPrependToAll_, item)
 #define ML99_PRIV_listPrependToAll_nil_IMPL ML99_nil_IMPL
 #define ML99_PRIV_listPrependToAll_cons_IMPL(x, xs, item)                                          \
-    ML99_cons(v(item), ML99_cons(v(x), ML99_listPrependToAll_IMPL(item, xs)))
+    ML99_cons(ML99_QUOTE(item), ML99_cons(ML99_QUOTE(x), ML99_listPrependToAll_IMPL(item, xs)))
 
 #define ML99_listMap_IMPL(f, list) ML99_matchWithArgs_IMPL(list, ML99_PRIV_listMap_, f)
 #define ML99_PRIV_listMap_nil_IMPL ML99_nil_IMPL
@@ -897,8 +897,8 @@
 
 #define ML99_listMapInitLast_IMPL(f_init, f_last, list)                                            \
     ML99_listAppendItem(                                                                           \
-        ML99_appl(v(f_last), ML99_listLast_IMPL(list)),                                            \
-        ML99_listMap(v(f_init), ML99_listInit_IMPL(list)))
+        ML99_appl(ML99_QUOTE(f_last), ML99_listLast_IMPL(list)),                                            \
+        ML99_listMap(ML99_QUOTE(f_init), ML99_listInit_IMPL(list)))
 
 #define ML99_listForInitLast_IMPL(list, f_init, f_last)                                            \
     ML99_listMapInitLast_IMPL(f_init, f_last, list)
@@ -912,11 +912,11 @@
     ML99_call(                                                                                     \
         ML99_boolMatchWithArgs,                                                                    \
         ML99_appl_IMPL(f, x),                                                                      \
-        v(ML99_PRIV_listFilter_cons_, x),                                                          \
+        ML99_QUOTE(ML99_PRIV_listFilter_cons_, x),                                                          \
         ML99_listFilter_IMPL(f, xs))
 
-#define ML99_PRIV_listFilter_cons_1_IMPL(x, rest)  v(ML99_CONS(x, rest))
-#define ML99_PRIV_listFilter_cons_0_IMPL(_x, rest) v(rest)
+#define ML99_PRIV_listFilter_cons_1_IMPL(x, rest)  ML99_QUOTE(ML99_CONS(x, rest))
+#define ML99_PRIV_listFilter_cons_0_IMPL(_x, rest) ML99_QUOTE(rest)
 // } (ML99_listFilter_IMPL)
 
 // ML99_listFilterMap_IMPL {
@@ -925,10 +925,10 @@
 
 #define ML99_PRIV_listFilterMap_nil_IMPL ML99_nil_IMPL
 #define ML99_PRIV_listFilterMap_cons_IMPL(x, xs, f)                                                \
-    ML99_call(ML99_matchWithArgs, ML99_appl_IMPL(f, x), v(ML99_PRIV_listFilterMap_cons_, f, xs))
+    ML99_call(ML99_matchWithArgs, ML99_appl_IMPL(f, x), ML99_QUOTE(ML99_PRIV_listFilterMap_cons_, f, xs))
 
 #define ML99_PRIV_listFilterMap_cons_just_IMPL(y, f, xs)                                           \
-    ML99_cons(v(y), ML99_listFilterMap_IMPL(f, xs))
+    ML99_cons(ML99_QUOTE(y), ML99_listFilterMap_IMPL(f, xs))
 #define ML99_PRIV_listFilterMap_cons_nothing_IMPL(_, f, xs) ML99_listFilterMap_IMPL(f, xs)
 // } (ML99_listFilterMap_IMPL)
 
@@ -937,15 +937,15 @@
 #define ML99_listEq_IMPL(cmp, list, other)                                                         \
     ML99_matchWithArgs_IMPL(list, ML99_PRIV_listEq_, other, cmp)
 
-#define ML99_PRIV_listEq_nil_IMPL(_, other, _cmp) v(ML99_IS_NIL(other))
+#define ML99_PRIV_listEq_nil_IMPL(_, other, _cmp) ML99_QUOTE(ML99_IS_NIL(other))
 #define ML99_PRIV_listEq_cons_IMPL(x, xs, other, cmp)                                              \
     ML99_matchWithArgs_IMPL(other, ML99_PRIV_listEq_cons_, x, xs, cmp)
 
 #define ML99_PRIV_listEq_cons_nil_IMPL ML99_false_IMPL
 #define ML99_PRIV_listEq_cons_cons_IMPL(other_x, other_xs, x, xs, cmp)                             \
     ML99_call(                                                                                     \
-        ML99_call(ML99_if, ML99_appl2_IMPL(cmp, x, other_x), v(ML99_listEq, ML99_false)),          \
-        v(cmp, xs, other_xs))
+        ML99_call(ML99_if, ML99_appl2_IMPL(cmp, x, other_x), ML99_QUOTE(ML99_listEq, ML99_false)),          \
+        ML99_QUOTE(cmp, xs, other_xs))
 // } (ML99_listEq_IMPL)
 
 #define ML99_listContains_IMPL(cmp, item, list)                                                    \
@@ -953,16 +953,16 @@
 #define ML99_PRIV_listContains_nil_IMPL ML99_false_IMPL
 #define ML99_PRIV_listContains_cons_IMPL(x, xs, item, cmp)                                         \
     ML99_call(                                                                                     \
-        ML99_call(ML99_if, ML99_appl2_IMPL(cmp, x, item), v(ML99_true, ML99_listContains)),        \
-        v(cmp, item, xs))
+        ML99_call(ML99_if, ML99_appl2_IMPL(cmp, x, item), ML99_QUOTE(ML99_true, ML99_listContains)),        \
+        ML99_QUOTE(cmp, item, xs))
 
 #define ML99_listTake_IMPL(n, list) ML99_matchWithArgs_IMPL(list, ML99_PRIV_listTake_, n)
 #define ML99_PRIV_listTake_nil_IMPL ML99_nil_IMPL
 #define ML99_PRIV_listTake_cons_IMPL(x, xs, i)                                                     \
     ML99_PRIV_IF(                                                                                  \
         ML99_NAT_EQ(i, 0),                                                                         \
-        v(ML99_NIL()),                                                                             \
-        ML99_cons(v(x), ML99_listTake_IMPL(ML99_DEC(i), xs)))
+        ML99_QUOTE(ML99_NIL()),                                                                             \
+        ML99_cons(ML99_QUOTE(x), ML99_listTake_IMPL(ML99_DEC(i), xs)))
 
 // ML99_listTakeWhile_IMPL {
 
@@ -973,17 +973,17 @@
     ML99_call(                                                                                     \
         ML99_boolMatchWithArgs,                                                                    \
         ML99_appl_IMPL(f, x),                                                                      \
-        v(ML99_PRIV_listTakeWhile_cons_, x, xs, f))
+        ML99_QUOTE(ML99_PRIV_listTakeWhile_cons_, x, xs, f))
 
 #define ML99_PRIV_listTakeWhile_cons_1_IMPL(x, xs, f)                                              \
-    ML99_cons(v(x), ML99_listTakeWhile_IMPL(f, xs))
+    ML99_cons(ML99_QUOTE(x), ML99_listTakeWhile_IMPL(f, xs))
 #define ML99_PRIV_listTakeWhile_cons_0_IMPL ML99_nil_IMPL
 // } (ML99_listTakeWhile_IMPL)
 
 #define ML99_listDrop_IMPL(n, list) ML99_matchWithArgs_IMPL(list, ML99_PRIV_listDrop_, n)
 #define ML99_PRIV_listDrop_nil_IMPL ML99_nil_IMPL
 #define ML99_PRIV_listDrop_cons_IMPL(x, xs, i)                                                     \
-    ML99_PRIV_IF(ML99_NAT_EQ(i, 0), v(ML99_CONS(x, xs)), ML99_listDrop_IMPL(ML99_DEC(i), xs))
+    ML99_PRIV_IF(ML99_NAT_EQ(i, 0), ML99_QUOTE(ML99_CONS(x, xs)), ML99_listDrop_IMPL(ML99_DEC(i), xs))
 
 // ML99_listDropWhile_IMPL {
 
@@ -994,9 +994,9 @@
     ML99_call(                                                                                     \
         ML99_boolMatchWithArgs,                                                                    \
         ML99_appl_IMPL(f, x),                                                                      \
-        v(ML99_PRIV_listDropWhile_cons_, x, xs, f))
+        ML99_QUOTE(ML99_PRIV_listDropWhile_cons_, x, xs, f))
 
-#define ML99_PRIV_listDropWhile_cons_0_IMPL(x, xs, _f) v(ML99_CONS(x, xs))
+#define ML99_PRIV_listDropWhile_cons_0_IMPL(x, xs, _f) ML99_QUOTE(ML99_CONS(x, xs))
 #define ML99_PRIV_listDropWhile_cons_1_IMPL(_x, xs, f) ML99_listDropWhile_IMPL(f, xs)
 // } (ML99_listDropWhile_IMPL)
 
@@ -1010,19 +1010,19 @@
 
 #define ML99_PRIV_listZip_cons_nil_IMPL ML99_nil_IMPL
 #define ML99_PRIV_listZip_cons_cons_IMPL(other_x, other_xs, x, xs)                                 \
-    ML99_cons(v(ML99_TUPLE(x, other_x)), ML99_listZip_IMPL(xs, other_xs))
+    ML99_cons(ML99_QUOTE(ML99_TUPLE(x, other_x)), ML99_listZip_IMPL(xs, other_xs))
 // } (ML99_listZip_IMPL)
 
 // ML99_listUnzip_IMPL {
 
 #define ML99_listUnzip_IMPL(list) ML99_match_IMPL(list, ML99_PRIV_listUnzip_)
 
-#define ML99_PRIV_listUnzip_nil_IMPL(_) v(ML99_TUPLE(ML99_NIL(), ML99_NIL()))
+#define ML99_PRIV_listUnzip_nil_IMPL(_) ML99_QUOTE(ML99_TUPLE(ML99_NIL(), ML99_NIL()))
 #define ML99_PRIV_listUnzip_cons_IMPL(x, xs)                                                       \
-    ML99_call(ML99_PRIV_listUnzipProgress, v(x), ML99_listUnzip_IMPL(xs))
+    ML99_call(ML99_PRIV_listUnzipProgress, ML99_QUOTE(x), ML99_listUnzip_IMPL(xs))
 
 #define ML99_PRIV_listUnzipProgress_IMPL(x, rest)                                                  \
-    v(ML99_TUPLE(ML99_PRIV_LIST_UNZIP_EXTEND(x, rest, 0), ML99_PRIV_LIST_UNZIP_EXTEND(x, rest, 1)))
+    ML99_QUOTE(ML99_TUPLE(ML99_PRIV_LIST_UNZIP_EXTEND(x, rest, 0), ML99_PRIV_LIST_UNZIP_EXTEND(x, rest, 1)))
 
 #define ML99_PRIV_LIST_UNZIP_EXTEND(x, rest, i)                                                    \
     ML99_CONS(ML99_TUPLE_GET(i)(x), ML99_TUPLE_GET(i)(rest))
@@ -1031,24 +1031,24 @@
 #define ML99_listReplicate_IMPL(n, item)                                                           \
     ML99_natMatchWithArgs_IMPL(n, ML99_PRIV_listReplicate_, item)
 #define ML99_PRIV_listReplicate_Z_IMPL          ML99_nil_IMPL
-#define ML99_PRIV_listReplicate_S_IMPL(n, item) ML99_cons(v(item), ML99_listReplicate_IMPL(n, item))
+#define ML99_PRIV_listReplicate_S_IMPL(n, item) ML99_cons(ML99_QUOTE(item), ML99_listReplicate_IMPL(n, item))
 
 // ML99_listPartition_IMPL {
 
 #define ML99_listPartition_IMPL(f, list)                                                           \
     ML99_listFoldr(                                                                                \
         ML99_appl_IMPL(ML99_PRIV_listPartitionAux, f),                                             \
-        v(ML99_TUPLE(ML99_NIL(), ML99_NIL())),                                                     \
-        v(list))
+        ML99_QUOTE(ML99_TUPLE(ML99_NIL(), ML99_NIL())),                                                     \
+        ML99_QUOTE(list))
 
 #define ML99_PRIV_listPartitionAux_IMPL(f, x, acc)                                                 \
     ML99_call(                                                                                     \
         ML99_boolMatchWithArgs,                                                                    \
         ML99_appl_IMPL(f, x),                                                                      \
-        v(ML99_PRIV_listPartition_, x, ML99_UNTUPLE(acc)))
+        ML99_QUOTE(ML99_PRIV_listPartition_, x, ML99_UNTUPLE(acc)))
 
-#define ML99_PRIV_listPartition_1_IMPL(x, fst, snd) v(ML99_TUPLE(ML99_CONS(x, fst), snd))
-#define ML99_PRIV_listPartition_0_IMPL(x, fst, snd) v(ML99_TUPLE(fst, ML99_CONS(x, snd)))
+#define ML99_PRIV_listPartition_1_IMPL(x, fst, snd) ML99_QUOTE(ML99_TUPLE(ML99_CONS(x, fst), snd))
+#define ML99_PRIV_listPartition_0_IMPL(x, fst, snd) ML99_QUOTE(ML99_TUPLE(fst, ML99_CONS(x, snd)))
 // } (ML99_listPartition_IMPL)
 
 #define ML99_listAppl_IMPL(f, list) ML99_listFoldl_IMPL(ML99_appl, f, list)
@@ -1058,14 +1058,14 @@
 #define ML99_listUnwrapCommaSep_IMPL(list)                                                         \
     ML99_PRIV_IF(                                                                                  \
         ML99_IS_NIL(list),                                                                         \
-        v(ML99_EMPTY()),                                                                           \
+        ML99_QUOTE(ML99_EMPTY()),                                                                           \
         ML99_variadicsTail(ML99_PRIV_listUnwrapCommaSepAux_IMPL(list)))
 
 #define ML99_PRIV_listUnwrapCommaSepAux_IMPL(xs) ML99_match_IMPL(xs, ML99_PRIV_listUnwrapCommaSep_)
 
 #define ML99_PRIV_listUnwrapCommaSep_nil_IMPL ML99_empty_IMPL
 #define ML99_PRIV_listUnwrapCommaSep_cons_IMPL(x, xs)                                              \
-    ML99_TERMS(v(, x), ML99_PRIV_listUnwrapCommaSepAux_IMPL(xs))
+    ML99_TERMS(ML99_QUOTE(, x), ML99_PRIV_listUnwrapCommaSepAux_IMPL(xs))
 // } (ML99_listUnwrapCommaSep_IMPL)
 
 // clang-format off

--- a/include/metalang99/maybe.h
+++ b/include/metalang99/maybe.h
@@ -31,7 +31,7 @@
  * #include <metalang99/maybe.h>
  *
  * // 1
- * ML99_isJust(ML99_just(v(123)))
+ * ML99_isJust(ML99_just(ML99_QUOTE(123)))
  *
  * // 0
  * ML99_isJust(ML99_nothing())
@@ -51,7 +51,7 @@
  * ML99_isNothing(ML99_nothing())
  *
  * // 0
- * ML99_isNothing(ML99_just(v(123)))
+ * ML99_isNothing(ML99_just(ML99_QUOTE(123)))
  * @endcode
  */
 #define ML99_isNothing(maybe) ML99_call(ML99_isNothing, maybe)
@@ -66,13 +66,13 @@
  * #include <metalang99/nat.h>
  *
  * // 1
- * ML99_maybeEq(v(ML99_natEq), ML99_just(v(123)), ML99_just(v(123)));
+ * ML99_maybeEq(ML99_QUOTE(ML99_natEq), ML99_just(ML99_QUOTE(123)), ML99_just(ML99_QUOTE(123)));
  *
  * // 0
- * ML99_maybeEq(v(ML99_natEq), ML99_just(v(4)), ML99_just(v(6)));
+ * ML99_maybeEq(ML99_QUOTE(ML99_natEq), ML99_just(ML99_QUOTE(4)), ML99_just(ML99_QUOTE(6)));
  *
  * // 0
- * ML99_maybeEq(v(ML99_natEq), ML99_just(v(4)), ML99_nothing());
+ * ML99_maybeEq(ML99_QUOTE(ML99_natEq), ML99_just(ML99_QUOTE(4)), ML99_nothing());
  * @endcode
  */
 #define ML99_maybeEq(cmp, maybe, other) ML99_call(ML99_maybeEq, cmp, maybe, other)
@@ -86,7 +86,7 @@
  * #include <metalang99/maybe.h>
  *
  * // 123
- * ML99_maybeUnwrap(ML99_just(v(123)))
+ * ML99_maybeUnwrap(ML99_just(ML99_QUOTE(123)))
  *
  * // Emits a fatal error.
  * ML99_maybeUnwrap(ML99_nothing())
@@ -101,11 +101,11 @@
 
 #ifndef DOXYGEN_IGNORE
 
-#define ML99_just_IMPL(x)      v(ML99_JUST(x))
-#define ML99_nothing_IMPL(...) v(ML99_NOTHING())
+#define ML99_just_IMPL(x)      ML99_QUOTE(ML99_JUST(x))
+#define ML99_nothing_IMPL(...) ML99_QUOTE(ML99_NOTHING())
 
-#define ML99_isJust_IMPL(maybe)    v(ML99_IS_JUST(maybe))
-#define ML99_isNothing_IMPL(maybe) v(ML99_IS_NOTHING(maybe))
+#define ML99_isJust_IMPL(maybe)    ML99_QUOTE(ML99_IS_JUST(maybe))
+#define ML99_isNothing_IMPL(maybe) ML99_QUOTE(ML99_IS_NOTHING(maybe))
 
 // ML99_maybeEq_IMPL {
 
@@ -114,14 +114,14 @@
 
 #define ML99_PRIV_maybeEq_just_IMPL(x, cmp, other)                                                 \
     ML99_matchWithArgs_IMPL(other, ML99_PRIV_maybeEq_just_, cmp, x)
-#define ML99_PRIV_maybeEq_nothing_IMPL(_, _cmp, other) v(ML99_IS_NOTHING(other))
+#define ML99_PRIV_maybeEq_nothing_IMPL(_, _cmp, other) ML99_QUOTE(ML99_IS_NOTHING(other))
 
 #define ML99_PRIV_maybeEq_just_just_IMPL(y, cmp, x) ML99_appl2_IMPL(cmp, x, y)
 #define ML99_PRIV_maybeEq_just_nothing_IMPL         ML99_false_IMPL
 // } (ML99_maybeEq_IMPL)
 
 #define ML99_maybeUnwrap_IMPL(maybe)       ML99_match_IMPL(maybe, ML99_PRIV_maybeUnwrap_)
-#define ML99_PRIV_maybeUnwrap_just_IMPL(x) v(x)
+#define ML99_PRIV_maybeUnwrap_just_IMPL(x) ML99_QUOTE(x)
 #define ML99_PRIV_maybeUnwrap_nothing_IMPL(_)                                                      \
     ML99_fatal(ML99_maybeUnwrap, expected ML99_just but found ML99_nothing)
 

--- a/include/metalang99/nat.h
+++ b/include/metalang99/nat.h
@@ -27,7 +27,7 @@
  * #include <metalang99/nat.h>
  *
  * // 6
- * ML99_inc(v(5))
+ * ML99_inc(ML99_QUOTE(5))
  * @endcode
  *
  * @note If @p x is #ML99_NAT_MAX, the result is 0.
@@ -43,7 +43,7 @@
  * #include <metalang99/nat.h>
  *
  * // 4
- * ML99_dec(v(5))
+ * ML99_dec(ML99_QUOTE(5))
  * @endcode
  *
  * @note If @p x is 0, the result is #ML99_NAT_MAX.
@@ -58,14 +58,14 @@
  * @code
  * #include <metalang99/nat.h>
  *
- * #define MATCH_Z_IMPL()  v(Billie)
- * #define MATCH_S_IMPL(x) v(Jean ~ x)
+ * #define MATCH_Z_IMPL()  ML99_QUOTE(Billie)
+ * #define MATCH_S_IMPL(x) ML99_QUOTE(Jean ~ x)
  *
  * // Billie
- * ML99_natMatch(v(0), v(MATCH_))
+ * ML99_natMatch(ML99_QUOTE(0), ML99_QUOTE(MATCH_))
  *
  * // Jean ~ 122
- * ML99_natMatch(v(123), v(MATCH_))
+ * ML99_natMatch(ML99_QUOTE(123), ML99_QUOTE(MATCH_))
  * @endcode
  *
  * @note This function calls @p f with #ML99_call, so no partial application occurs, and so
@@ -81,14 +81,14 @@
  * @code
  * #include <metalang99/nat.h>
  *
- * #define MATCH_Z_IMPL(x, y, z)    v(Billie ~ x y z)
- * #define MATCH_S_IMPL(n, x, y, z) v(Jean ~ n ~ x y z)
+ * #define MATCH_Z_IMPL(x, y, z)    ML99_QUOTE(Billie ~ x y z)
+ * #define MATCH_S_IMPL(n, x, y, z) ML99_QUOTE(Jean ~ n ~ x y z)
  *
  * // Billie ~ 1 2 3
- * ML99_natMatchWithArgs(v(0), v(MATCH_), v(1, 2, 3))
+ * ML99_natMatchWithArgs(ML99_QUOTE(0), ML99_QUOTE(MATCH_), ML99_QUOTE(1, 2, 3))
  *
  * // Jean ~ 122 ~ 1 2 3
- * ML99_natMatchWithArgs(v(123), v(MATCH_), v(1, 2, 3))
+ * ML99_natMatchWithArgs(ML99_QUOTE(123), ML99_QUOTE(MATCH_), ML99_QUOTE(1, 2, 3))
  * @endcode
  */
 #define ML99_natMatchWithArgs(x, matcher, ...)                                                     \
@@ -103,10 +103,10 @@
  * #include <metalang99/nat.h>
  *
  * // 1
- * ML99_natEq(v(5), v(5))
+ * ML99_natEq(ML99_QUOTE(5), ML99_QUOTE(5))
  *
  * // 0
- * ML99_natEq(v(3), v(8))
+ * ML99_natEq(ML99_QUOTE(3), ML99_QUOTE(8))
  * @endcode
  */
 #define ML99_natEq(x, y) ML99_call(ML99_natEq, x, y)
@@ -120,10 +120,10 @@
  * #include <metalang99/nat.h>
  *
  * // 0
- * ML99_natNeq(v(5), v(5))
+ * ML99_natNeq(ML99_QUOTE(5), ML99_QUOTE(5))
  *
  * // 1
- * ML99_natNeq(v(3), v(8))
+ * ML99_natNeq(ML99_QUOTE(3), ML99_QUOTE(8))
  * @endcode
  */
 #define ML99_natNeq(x, y) ML99_call(ML99_natNeq, x, y)
@@ -137,10 +137,10 @@
  * #include <metalang99/nat.h>
  *
  * // 1
- * ML99_greater(v(8), v(3))
+ * ML99_greater(ML99_QUOTE(8), ML99_QUOTE(3))
  *
  * // 0
- * ML99_greater(v(3), v(8))
+ * ML99_greater(ML99_QUOTE(3), ML99_QUOTE(8))
  * @endcode
  */
 #define ML99_greater(x, y) ML99_call(ML99_greater, x, y)
@@ -154,10 +154,10 @@
  * #include <metalang99/nat.h>
  *
  * // 1
- * ML99_greaterEq(v(8), v(8))
+ * ML99_greaterEq(ML99_QUOTE(8), ML99_QUOTE(8))
  *
  * // 0
- * ML99_greaterEq(v(3), v(8))
+ * ML99_greaterEq(ML99_QUOTE(3), ML99_QUOTE(8))
  * @endcode
  */
 #define ML99_greaterEq(x, y) ML99_call(ML99_greaterEq, x, y)
@@ -171,10 +171,10 @@
  * #include <metalang99/nat.h>
  *
  * // 1
- * ML99_lesser(v(3), v(8))
+ * ML99_lesser(ML99_QUOTE(3), ML99_QUOTE(8))
  *
  * // 0
- * ML99_lesser(v(8), v(3))
+ * ML99_lesser(ML99_QUOTE(8), ML99_QUOTE(3))
  * @endcode
  */
 #define ML99_lesser(x, y) ML99_call(ML99_lesser, x, y)
@@ -188,10 +188,10 @@
  * #include <metalang99/nat.h>
  *
  * // 1
- * ML99_lesserEq(v(8), v(8))
+ * ML99_lesserEq(ML99_QUOTE(8), ML99_QUOTE(8))
  *
  * // 0
- * ML99_lesserEq(v(8), v(3))
+ * ML99_lesserEq(ML99_QUOTE(8), ML99_QUOTE(3))
  * @endcode
  */
 #define ML99_lesserEq(x, y) ML99_call(ML99_lesserEq, x, y)
@@ -205,7 +205,7 @@
  * #include <metalang99/nat.h>
  *
  * // 11
- * ML99_add(v(5), v(6))
+ * ML99_add(ML99_QUOTE(5), ML99_QUOTE(6))
  * @endcode
  */
 #define ML99_add(x, y) ML99_call(ML99_add, x, y)
@@ -219,7 +219,7 @@
  * #include <metalang99/nat.h>
  *
  * // 6
- * ML99_sub(v(11), v(5))
+ * ML99_sub(ML99_QUOTE(11), ML99_QUOTE(5))
  * @endcode
  */
 #define ML99_sub(x, y) ML99_call(ML99_sub, x, y)
@@ -233,7 +233,7 @@
  * #include <metalang99/nat.h>
  *
  * // 12
- * ML99_mul(v(3), v(4))
+ * ML99_mul(ML99_QUOTE(3), ML99_QUOTE(4))
  * @endcode
  */
 #define ML99_mul(x, y) ML99_call(ML99_mul, x, y)
@@ -247,7 +247,7 @@
  * #include <metalang99/nat.h>
  *
  * // 3
- * ML99_div(v(12), v(4))
+ * ML99_div(ML99_QUOTE(12), ML99_QUOTE(4))
  * @endcode
  *
  * @note A compile-time error if \f$\frac{x}{y}\f$ is not a natural number.
@@ -264,13 +264,13 @@
  * #include <metalang99/nat.h>
  *
  * // ML99_just(3)
- * ML99_divChecked(v(12), v(4))
+ * ML99_divChecked(ML99_QUOTE(12), ML99_QUOTE(4))
  *
  * // ML99_nothing()
- * ML99_divChecked(v(14), v(5))
+ * ML99_divChecked(ML99_QUOTE(14), ML99_QUOTE(5))
  *
  * // ML99_nothing()
- * ML99_divChecked(v(1), v(0))
+ * ML99_divChecked(ML99_QUOTE(1), ML99_QUOTE(0))
  * @endcode
  */
 #define ML99_divChecked(x, y) ML99_call(ML99_divChecked, x, y)
@@ -284,7 +284,7 @@
  * #include <metalang99/nat.h>
  *
  * // 2
- * ML99_mod(v(8), v(3))
+ * ML99_mod(ML99_QUOTE(8), ML99_QUOTE(3))
  * @endcode
  *
  * @note A compile-time error if @p y is 0.
@@ -300,7 +300,7 @@
  * #include <metalang99/nat.h>
  *
  * // 15
- * ML99_add3(v(1), v(6), v(8))
+ * ML99_add3(ML99_QUOTE(1), ML99_QUOTE(6), ML99_QUOTE(8))
  * @endcode
  */
 #define ML99_add3(x, y, z) ML99_call(ML99_add3, x, y, z)
@@ -314,7 +314,7 @@
  * #include <metalang99/nat.h>
  *
  * // 3
- * ML99_sub3(v(8), v(2), v(3))
+ * ML99_sub3(ML99_QUOTE(8), ML99_QUOTE(2), ML99_QUOTE(3))
  * @endcode
  */
 #define ML99_sub3(x, y, z) ML99_call(ML99_sub3, x, y, z)
@@ -328,7 +328,7 @@
  * #include <metalang99/nat.h>
  *
  * // 24
- * ML99_mul3(v(2), v(3), v(4))
+ * ML99_mul3(ML99_QUOTE(2), ML99_QUOTE(3), ML99_QUOTE(4))
  * @endcode
  */
 #define ML99_mul3(x, y, z) ML99_call(ML99_mul3, x, y, z)
@@ -342,7 +342,7 @@
  * #include <metalang99/nat.h>
  *
  * // 5
- * ML99_div(v(30), v(3), v(2))
+ * ML99_div(ML99_QUOTE(30), ML99_QUOTE(3), ML99_QUOTE(2))
  * @endcode
  *
  * @note A compile-time error if \f$\frac{(\frac{x}{y})}{z}\f$ is not a natural number.
@@ -358,7 +358,7 @@
  * #include <metalang99/nat.h>
  *
  * // 5
- * ML99_min(v(5), v(7))
+ * ML99_min(ML99_QUOTE(5), ML99_QUOTE(7))
  * @endcode
  */
 #define ML99_min(x, y) ML99_call(ML99_min, x, y)
@@ -372,7 +372,7 @@
  * #include <metalang99/nat.h>
  *
  * // 7
- * ML99_max(v(5), v(7))
+ * ML99_max(ML99_QUOTE(5), ML99_QUOTE(7))
  * @endcode
  */
 #define ML99_max(x, y) ML99_call(ML99_max, x, y)
@@ -385,13 +385,13 @@
  * @code
  * #include <metalang99/nat.h>
  *
- * #define F_IMPL(x) ML99_TERMS(ML99_assertIsNat(v(x)), ML99_inc(v(x)))
+ * #define F_IMPL(x) ML99_TERMS(ML99_assertIsNat(ML99_QUOTE(x)), ML99_inc(ML99_QUOTE(x)))
  *
  * // 6
- * ML99_call(F, v(5))
+ * ML99_call(F, ML99_QUOTE(5))
  *
  * // A compile-time number mismatch error.
- * ML99_call(F, v(blah))
+ * ML99_call(F, ML99_QUOTE(blah))
  * @endcode
  */
 #define ML99_assertIsNat(x) ML99_call(ML99_assertIsNat, x)
@@ -426,46 +426,46 @@
 
 // Comparison operators {
 
-#define ML99_natEq_IMPL(x, y)  v(ML99_NAT_EQ(x, y))
-#define ML99_natNeq_IMPL(x, y) v(ML99_NAT_NEQ(x, y))
+#define ML99_natEq_IMPL(x, y)  ML99_QUOTE(ML99_NAT_EQ(x, y))
+#define ML99_natNeq_IMPL(x, y) ML99_QUOTE(ML99_NAT_NEQ(x, y))
 
 #define ML99_lesser_IMPL(x, y)                                                                     \
     ML99_PRIV_IF(                                                                                  \
         ML99_NAT_EQ(y, 0),                                                                         \
-        v(ML99_PRIV_FALSE()),                                                                      \
+        ML99_QUOTE(ML99_PRIV_FALSE()),                                                                      \
         ML99_PRIV_IF(                                                                              \
             ML99_NAT_EQ(x, ML99_DEC(y)),                                                           \
-            v(ML99_PRIV_TRUE()),                                                                   \
+            ML99_QUOTE(ML99_PRIV_TRUE()),                                                                   \
             ML99_callUneval(ML99_lesser, x, ML99_DEC(y))))
 
 #define ML99_lesserEq_IMPL(x, y) ML99_greaterEq_IMPL(y, x)
 
 #define ML99_greater_IMPL(x, y) ML99_lesser_IMPL(y, x)
 #define ML99_greaterEq_IMPL(x, y)                                                                  \
-    ML99_PRIV_IF(ML99_NAT_EQ(x, y), v(ML99_PRIV_TRUE()), ML99_greater_IMPL(x, y))
+    ML99_PRIV_IF(ML99_NAT_EQ(x, y), ML99_QUOTE(ML99_PRIV_TRUE()), ML99_greater_IMPL(x, y))
 // } (Comparison operators)
 
 // Arithmetical operators {
 
-#define ML99_inc_IMPL(x) v(ML99_INC(x))
-#define ML99_dec_IMPL(x) v(ML99_DEC(x))
+#define ML99_inc_IMPL(x) ML99_QUOTE(ML99_INC(x))
+#define ML99_dec_IMPL(x) ML99_QUOTE(ML99_DEC(x))
 
 #define ML99_add_IMPL(x, y)                                                                        \
-    ML99_PRIV_IF(ML99_NAT_EQ(y, 0), v(x), ML99_callUneval(ML99_add, ML99_INC(x), ML99_DEC(y)))
+    ML99_PRIV_IF(ML99_NAT_EQ(y, 0), ML99_QUOTE(x), ML99_callUneval(ML99_add, ML99_INC(x), ML99_DEC(y)))
 #define ML99_sub_IMPL(x, y)                                                                        \
-    ML99_PRIV_IF(ML99_NAT_EQ(y, 0), v(x), ML99_callUneval(ML99_sub, ML99_DEC(x), ML99_DEC(y)))
+    ML99_PRIV_IF(ML99_NAT_EQ(y, 0), ML99_QUOTE(x), ML99_callUneval(ML99_sub, ML99_DEC(x), ML99_DEC(y)))
 #define ML99_mul_IMPL(x, y)                                                                        \
-    ML99_PRIV_IF(ML99_NAT_EQ(y, 0), v(0), ML99_add(v(x), ML99_callUneval(ML99_mul, x, ML99_DEC(y))))
+    ML99_PRIV_IF(ML99_NAT_EQ(y, 0), ML99_QUOTE(0), ML99_add(ML99_QUOTE(x), ML99_callUneval(ML99_mul, x, ML99_DEC(y))))
 
-#define ML99_add3_IMPL(x, y, z) ML99_add(ML99_add_IMPL(x, y), v(z))
-#define ML99_sub3_IMPL(x, y, z) ML99_sub(ML99_sub_IMPL(x, y), v(z))
-#define ML99_mul3_IMPL(x, y, z) ML99_mul(ML99_mul_IMPL(x, y), v(z))
-#define ML99_div3_IMPL(x, y, z) ML99_div(ML99_div_IMPL(x, y), v(z))
+#define ML99_add3_IMPL(x, y, z) ML99_add(ML99_add_IMPL(x, y), ML99_QUOTE(z))
+#define ML99_sub3_IMPL(x, y, z) ML99_sub(ML99_sub_IMPL(x, y), ML99_QUOTE(z))
+#define ML99_mul3_IMPL(x, y, z) ML99_mul(ML99_mul_IMPL(x, y), ML99_QUOTE(z))
+#define ML99_div3_IMPL(x, y, z) ML99_div(ML99_div_IMPL(x, y), ML99_QUOTE(z))
 
-#define ML99_min_IMPL(x, y) ML99_call(ML99_if, ML99_lesser_IMPL(x, y), v(x, y))
-#define ML99_max_IMPL(x, y) ML99_call(ML99_if, ML99_lesser_IMPL(x, y), v(y, x))
+#define ML99_min_IMPL(x, y) ML99_call(ML99_if, ML99_lesser_IMPL(x, y), ML99_QUOTE(x, y))
+#define ML99_max_IMPL(x, y) ML99_call(ML99_if, ML99_lesser_IMPL(x, y), ML99_QUOTE(y, x))
 
-#define ML99_divChecked_IMPL(x, y) v(ML99_DIV_CHECKED(x, y))
+#define ML99_divChecked_IMPL(x, y) ML99_QUOTE(ML99_DIV_CHECKED(x, y))
 
 // ML99_mod_IMPL {
 
@@ -478,7 +478,7 @@
 #define ML99_PRIV_modAux_IMPL(x, y, acc)                                                           \
     ML99_PRIV_IF(                                                                                  \
         ML99_PRIV_OR(ML99_NAT_EQ(x, 0), ML99_IS_JUST(ML99_DIV_CHECKED(x, y))),                     \
-        v(acc),                                                                                    \
+        ML99_QUOTE(acc),                                                                                    \
         ML99_callUneval(ML99_PRIV_modAux, ML99_DEC(x), y, ML99_INC(acc)))
 // } (ML99_mod_IMPL)
 
@@ -487,7 +487,7 @@
 #define ML99_assertIsNat_IMPL(x)                                                                   \
     ML99_PRIV_IF(                                                                                  \
         ML99_PRIV_NAT_EQ(x, x),                                                                    \
-        v(ML99_PRIV_EMPTY()),                                                                      \
+        ML99_QUOTE(ML99_PRIV_EMPTY()),                                                                      \
         ML99_PRIV_ASSERT_IS_NAT_FATAL(x, ML99_NAT_MAX))
 
 // clang-format off

--- a/include/metalang99/nat/div.h
+++ b/include/metalang99/nat/div.h
@@ -10,7 +10,7 @@
 #define ML99_div_IMPL(x, y)                                                                        \
     ML99_matchWithArgs_IMPL(ML99_PRIV_DIV_CHECKED(x, y), ML99_PRIV_DIV_, x, y)
 #define ML99_PRIV_DIV_nothing_IMPL(_, x, y) ML99_fatal(ML99_div, x is not divisible by y)
-#define ML99_PRIV_DIV_just_IMPL(n, _x, _y)  v(n)
+#define ML99_PRIV_DIV_just_IMPL(n, _x, _y)  ML99_QUOTE(n)
 
 #define ML99_PRIV_DIV_CHECKED(x, y)                                                                \
     ML99_PRIV_IF(                                                                                  \

--- a/include/metalang99/priv/tuple.h
+++ b/include/metalang99/priv/tuple.h
@@ -23,7 +23,7 @@
  * Checks whether @p x takes the form `(...) (...) ...`.
  *
  * This often happens when you miss a comma between items:
- *  - `v(123) v(456)`
+ *  - `ML99_QUOTE(123) ML99_QUOTE(456)`
  *  - `(Foo, int) (Bar, int)` (as in Datatype99)
  *  - etc.
  */

--- a/include/metalang99/seq.h
+++ b/include/metalang99/seq.h
@@ -49,10 +49,10 @@
  * #include <metalang99/seq.h>
  *
  * // 1
- * ML99_seqIsEmpty(v())
+ * ML99_seqIsEmpty(ML99_QUOTE())
  *
  * // 0
- * ML99_seqIsEmpty(v((~)(~)(~)))
+ * ML99_seqIsEmpty(ML99_QUOTE((~)(~)(~)))
  * @endcode
  */
 #define ML99_seqIsEmpty(seq) ML99_call(ML99_seqIsEmpty, seq)
@@ -68,7 +68,7 @@
  * #include <metalang99/seq.h>
  *
  * // 2
- * ML99_seqGet(1)(v((1)(2)(3)))
+ * ML99_seqGet(1)(ML99_QUOTE((1)(2)(3)))
  * @endcode
  */
 #define ML99_seqGet(i) ML99_PRIV_CAT(ML99_PRIV_seqGet_, i)
@@ -85,7 +85,7 @@
  * #include <metalang99/seq.h>
  *
  * // (2)(3)
- * ML99_seqTail(v((1)(2)(3)))
+ * ML99_seqTail(ML99_QUOTE((1)(2)(3)))
  * @endcode
  */
 #define ML99_seqTail(seq) ML99_call(ML99_seqTail, seq)
@@ -100,11 +100,11 @@
  * @code
  * #include <metalang99/seq.h>
  *
- * #define F_IMPL(x) v(@x)
+ * #define F_IMPL(x) ML99_QUOTE(@x)
  * #define F_ARITY   1
  *
  * // @x @y @z
- * ML99_seqForEach(v(F), v((x)(y)(z)))
+ * ML99_seqForEach(ML99_QUOTE(F), ML99_QUOTE((x)(y)(z)))
  * @endcode
  */
 #define ML99_seqForEach(f, seq) ML99_call(ML99_seqForEach, f, seq)
@@ -117,11 +117,11 @@
  * @code
  * #include <metalang99/seq.h>
  *
- * #define F_IMPL(i, x) v(@x##i)
+ * #define F_IMPL(i, x) ML99_QUOTE(@x##i)
  * #define F_ARITY      2
  *
  * // @x0 @y1 @z2
- * ML99_seqForEachI(v(F), v((x)(y)(z)))
+ * ML99_seqForEachI(ML99_QUOTE(F), ML99_QUOTE((x)(y)(z)))
  * @endcode
  */
 #define ML99_seqForEachI(f, seq) ML99_call(ML99_seqForEachI, f, seq)
@@ -132,7 +132,7 @@
 
 #ifndef DOXYGEN_IGNORE
 
-#define ML99_seqIsEmpty_IMPL(seq) v(ML99_SEQ_IS_EMPTY(seq))
+#define ML99_seqIsEmpty_IMPL(seq) ML99_QUOTE(ML99_SEQ_IS_EMPTY(seq))
 
 #define ML99_PRIV_seqGet_0(seq) ML99_call(ML99_PRIV_seqGet_0, seq)
 #define ML99_PRIV_seqGet_1(seq) ML99_call(ML99_PRIV_seqGet_1, seq)
@@ -143,14 +143,14 @@
 #define ML99_PRIV_seqGet_6(seq) ML99_call(ML99_PRIV_seqGet_6, seq)
 #define ML99_PRIV_seqGet_7(seq) ML99_call(ML99_PRIV_seqGet_7, seq)
 
-#define ML99_PRIV_seqGet_0_IMPL(seq) v(ML99_SEQ_GET(0)(seq))
-#define ML99_PRIV_seqGet_1_IMPL(seq) v(ML99_SEQ_GET(1)(seq))
-#define ML99_PRIV_seqGet_2_IMPL(seq) v(ML99_SEQ_GET(2)(seq))
-#define ML99_PRIV_seqGet_3_IMPL(seq) v(ML99_SEQ_GET(3)(seq))
-#define ML99_PRIV_seqGet_4_IMPL(seq) v(ML99_SEQ_GET(4)(seq))
-#define ML99_PRIV_seqGet_5_IMPL(seq) v(ML99_SEQ_GET(5)(seq))
-#define ML99_PRIV_seqGet_6_IMPL(seq) v(ML99_SEQ_GET(6)(seq))
-#define ML99_PRIV_seqGet_7_IMPL(seq) v(ML99_SEQ_GET(7)(seq))
+#define ML99_PRIV_seqGet_0_IMPL(seq) ML99_QUOTE(ML99_SEQ_GET(0)(seq))
+#define ML99_PRIV_seqGet_1_IMPL(seq) ML99_QUOTE(ML99_SEQ_GET(1)(seq))
+#define ML99_PRIV_seqGet_2_IMPL(seq) ML99_QUOTE(ML99_SEQ_GET(2)(seq))
+#define ML99_PRIV_seqGet_3_IMPL(seq) ML99_QUOTE(ML99_SEQ_GET(3)(seq))
+#define ML99_PRIV_seqGet_4_IMPL(seq) ML99_QUOTE(ML99_SEQ_GET(4)(seq))
+#define ML99_PRIV_seqGet_5_IMPL(seq) ML99_QUOTE(ML99_SEQ_GET(5)(seq))
+#define ML99_PRIV_seqGet_6_IMPL(seq) ML99_QUOTE(ML99_SEQ_GET(6)(seq))
+#define ML99_PRIV_seqGet_7_IMPL(seq) ML99_QUOTE(ML99_SEQ_GET(7)(seq))
 
 #define ML99_PRIV_SEQ_GET_0(seq) ML99_PRIV_UNTUPLE(ML99_PRIV_HEAD(ML99_PRIV_SEQ_SEPARATE seq))
 #define ML99_PRIV_SEQ_GET_1(seq) ML99_PRIV_SEQ_GET_0(ML99_SEQ_TAIL(seq))
@@ -163,11 +163,11 @@
 
 #define ML99_PRIV_SEQ_SEPARATE(...) (__VA_ARGS__),
 
-#define ML99_seqTail_IMPL(seq) v(ML99_SEQ_TAIL(seq))
+#define ML99_seqTail_IMPL(seq) ML99_QUOTE(ML99_SEQ_TAIL(seq))
 
 #define ML99_seqForEach_IMPL(f, seq)                                                               \
     ML99_PRIV_CAT(ML99_PRIV_seqForEach_, ML99_SEQ_IS_EMPTY(seq))(f, seq)
-#define ML99_PRIV_seqForEach_1(...) v(ML99_PRIV_EMPTY())
+#define ML99_PRIV_seqForEach_1(...) ML99_QUOTE(ML99_PRIV_EMPTY())
 #define ML99_PRIV_seqForEach_0(f, seq)                                                             \
     ML99_TERMS(                                                                                    \
         ML99_appl_IMPL(f, ML99_SEQ_GET(0)(seq)),                                                   \
@@ -176,7 +176,7 @@
 #define ML99_seqForEachI_IMPL(f, seq) ML99_PRIV_seqForEachIAux_IMPL(f, 0, seq)
 #define ML99_PRIV_seqForEachIAux_IMPL(f, i, seq)                                                   \
     ML99_PRIV_CAT(ML99_PRIV_seqForEachI_, ML99_SEQ_IS_EMPTY(seq))(f, i, seq)
-#define ML99_PRIV_seqForEachI_1(...) v(ML99_PRIV_EMPTY())
+#define ML99_PRIV_seqForEachI_1(...) ML99_QUOTE(ML99_PRIV_EMPTY())
 #define ML99_PRIV_seqForEachI_0(f, i, seq)                                                         \
     ML99_TERMS(                                                                                    \
         ML99_appl2_IMPL(f, i, ML99_SEQ_GET(0)(seq)),                                               \

--- a/include/metalang99/tuple.h
+++ b/include/metalang99/tuple.h
@@ -32,21 +32,21 @@
  * #include <metalang99/tuple.h>
  *
  * // (1, 2, 3)
- * ML99_tuple(v(1, 2, 3))
+ * ML99_tuple(ML99_QUOTE(1, 2, 3))
  * @endcode
  */
 #define ML99_tuple(...) ML99_call(ML99_tuple, __VA_ARGS__)
 
 /**
- * Transforms a sequence of arguments into `(v(...))`.
+ * Transforms a sequence of arguments into `(ML99_QUOTE(...))`.
  *
  * # Examples
  *
  * @code
  * #include <metalang99/tuple.h>
  *
- * // (v(1, 2, 3))
- * ML99_tupleEval(v(1, 2, 3))
+ * // (ML99_QUOTE(1, 2, 3))
+ * ML99_tupleEval(ML99_QUOTE(1, 2, 3))
  * @endcode
  *
  * @deprecated I have seen no single use case over time. Please, [open an
@@ -65,7 +65,7 @@
  * #include <metalang99/tuple.h>
  *
  * // 1, 2, 3
- * ML99_untuple(v((1, 2, 3)))
+ * ML99_untuple(ML99_QUOTE((1, 2, 3)))
  * @endcode
  */
 #define ML99_untuple(x) ML99_call(ML99_untuple, x)
@@ -86,7 +86,7 @@
  * #include <metalang99/tuple.h>
  *
  * // 1, 2, 3
- * ML99_untupleEval(v((v(1, 2, 3))))
+ * ML99_untupleEval(ML99_QUOTE((ML99_QUOTE(1, 2, 3))))
  * @endcode
  *
  * @deprecated For the same reason as #ML99_tupleEval.
@@ -104,10 +104,10 @@
  * #include <metalang99/tuple.h>
  *
  * // 0
- * ML99_isTuple(v(123))
+ * ML99_isTuple(ML99_QUOTE(123))
  *
  * // 1
- * ML99_isTuple(v((123)))
+ * ML99_isTuple(ML99_QUOTE((123)))
  * @endcode
  */
 #define ML99_isTuple(x) ML99_call(ML99_isTuple, x)
@@ -131,13 +131,13 @@
  * #include <metalang99/tuple.h>
  *
  * // 1
- * ML99_isUntuple(v(123))
+ * ML99_isUntuple(ML99_QUOTE(123))
  *
  * // 0
- * ML99_isUntuple(v((123)))
+ * ML99_isUntuple(ML99_QUOTE((123)))
  *
  * // 1
- * ML99_isUntuple(v((123) (456) (789)))
+ * ML99_isUntuple(ML99_QUOTE((123) (456) (789)))
  * @endcode
  */
 #define ML99_isUntuple(x) ML99_call(ML99_isUntuple, x)
@@ -153,10 +153,10 @@
  * #include <metalang99/tuple.h>
  *
  * // 3
- * ML99_tupleCount(v((~, ~, ~)))
+ * ML99_tupleCount(ML99_QUOTE((~, ~, ~)))
  *
  * // 1
- * ML99_tupleCount(v(()))
+ * ML99_tupleCount(ML99_QUOTE(()))
  * @endcode
  */
 #define ML99_tupleCount(x) ML99_call(ML99_tupleCount, x)
@@ -170,10 +170,10 @@
  * #include <metalang99/tuple.h>
  *
  * // 1
- * ML99_tupleIsSingle(v((~)))
+ * ML99_tupleIsSingle(ML99_QUOTE((~)))
  *
  * // 0
- * ML99_tupleIsSingle(v((~, ~, ~)))
+ * ML99_tupleIsSingle(ML99_QUOTE((~, ~, ~)))
  * @endcode
  */
 #define ML99_tupleIsSingle(x) ML99_call(ML99_tupleIsSingle, x)
@@ -189,7 +189,7 @@
  * #include <metalang99/tuple.h>
  *
  * // 2
- * ML99_tupleGet(1)(v((1, 2, 3)))
+ * ML99_tupleGet(1)(ML99_QUOTE((1, 2, 3)))
  * @endcode
  */
 #define ML99_tupleGet(i) ML99_PRIV_CAT(ML99_PRIV_tupleGet_, i)
@@ -205,7 +205,7 @@
  * #include <metalang99/tuple.h>
  *
  * // 2, 3
- * ML99_tupleTail(v((1, 2, 3)))
+ * ML99_tupleTail(ML99_QUOTE((1, 2, 3)))
  * @endcode
  */
 #define ML99_tupleTail(x) ML99_call(ML99_tupleTail, x)
@@ -219,7 +219,7 @@
  * #include <metalang99/tuple.h>
  *
  * // (1, 2, 3)
- * ML99_tupleAppend(ML99_tuple(v(1)), v(2, 3))
+ * ML99_tupleAppend(ML99_tuple(ML99_QUOTE(1)), ML99_QUOTE(2, 3))
  * @endcode
  */
 #define ML99_tupleAppend(x, ...) ML99_call(ML99_tupleAppend, x, __VA_ARGS__)
@@ -233,7 +233,7 @@
  * #include <metalang99/tuple.h>
  *
  * // (1, 2, 3)
- * ML99_tuplePrepend(ML99_tuple(v(3)), v(1, 2))
+ * ML99_tuplePrepend(ML99_tuple(ML99_QUOTE(3)), ML99_QUOTE(1, 2))
  * @endcode
  */
 #define ML99_tuplePrepend(x, ...) ML99_call(ML99_tuplePrepend, x, __VA_ARGS__)
@@ -256,13 +256,13 @@
  * @code
  * #include <metalang99/tuple.h>
  *
- * #define F_IMPL(x) ML99_TERMS(ML99_assertIsTuple(v(x)), ML99_untuple(v(x)))
+ * #define F_IMPL(x) ML99_TERMS(ML99_assertIsTuple(ML99_QUOTE(x)), ML99_untuple(ML99_QUOTE(x)))
  *
  * // 1, 2, 3
- * ML99_call(F, v((1, 2, 3)))
+ * ML99_call(F, ML99_QUOTE((1, 2, 3)))
  *
  * // A compile-time tuple mismatch error.
- * ML99_call(F, v(123))
+ * ML99_call(F, ML99_QUOTE(123))
  * @endcode
  */
 #define ML99_assertIsTuple(x) ML99_call(ML99_assertIsTuple, x)
@@ -280,18 +280,18 @@
 
 #ifndef DOXYGEN_IGNORE
 
-#define ML99_tuple_IMPL(...)     v(ML99_TUPLE(__VA_ARGS__))
-#define ML99_tupleEval_IMPL(...) v((v(__VA_ARGS__)))
+#define ML99_tuple_IMPL(...)     ML99_QUOTE(ML99_TUPLE(__VA_ARGS__))
+#define ML99_tupleEval_IMPL(...) ML99_QUOTE((ML99_QUOTE(__VA_ARGS__)))
 #define ML99_untuple_IMPL(x)                                                                       \
     ML99_PRIV_IF(ML99_IS_TUPLE(x), ML99_PRIV_UNTUPLE_TERM, ML99_PRIV_NOT_TUPLE_ERROR)(x)
 #define ML99_untupleChecked_IMPL(x) ML99_untuple_IMPL(x)
 #define ML99_untupleEval_IMPL(x)    ML99_PRIV_EXPAND x
-#define ML99_isTuple_IMPL(x)        v(ML99_IS_TUPLE(x))
-#define ML99_isUntuple_IMPL(x)      v(ML99_IS_UNTUPLE(x))
-#define ML99_tupleCount_IMPL(x)     v(ML99_TUPLE_COUNT(x))
-#define ML99_tupleIsSingle_IMPL(x)  v(ML99_TUPLE_IS_SINGLE(x))
+#define ML99_isTuple_IMPL(x)        ML99_QUOTE(ML99_IS_TUPLE(x))
+#define ML99_isUntuple_IMPL(x)      ML99_QUOTE(ML99_IS_UNTUPLE(x))
+#define ML99_tupleCount_IMPL(x)     ML99_QUOTE(ML99_TUPLE_COUNT(x))
+#define ML99_tupleIsSingle_IMPL(x)  ML99_QUOTE(ML99_TUPLE_IS_SINGLE(x))
 
-#define ML99_PRIV_UNTUPLE_TERM(x) v(ML99_UNTUPLE(x))
+#define ML99_PRIV_UNTUPLE_TERM(x) ML99_QUOTE(ML99_UNTUPLE(x))
 
 #define ML99_PRIV_tupleGet_0(x) ML99_call(ML99_PRIV_tupleGet_0, x)
 #define ML99_PRIV_tupleGet_1(x) ML99_call(ML99_PRIV_tupleGet_1, x)
@@ -302,14 +302,14 @@
 #define ML99_PRIV_tupleGet_6(x) ML99_call(ML99_PRIV_tupleGet_6, x)
 #define ML99_PRIV_tupleGet_7(x) ML99_call(ML99_PRIV_tupleGet_7, x)
 
-#define ML99_PRIV_tupleGet_0_IMPL(x) v(ML99_TUPLE_GET(0)(x))
-#define ML99_PRIV_tupleGet_1_IMPL(x) v(ML99_TUPLE_GET(1)(x))
-#define ML99_PRIV_tupleGet_2_IMPL(x) v(ML99_TUPLE_GET(2)(x))
-#define ML99_PRIV_tupleGet_3_IMPL(x) v(ML99_TUPLE_GET(3)(x))
-#define ML99_PRIV_tupleGet_4_IMPL(x) v(ML99_TUPLE_GET(4)(x))
-#define ML99_PRIV_tupleGet_5_IMPL(x) v(ML99_TUPLE_GET(5)(x))
-#define ML99_PRIV_tupleGet_6_IMPL(x) v(ML99_TUPLE_GET(6)(x))
-#define ML99_PRIV_tupleGet_7_IMPL(x) v(ML99_TUPLE_GET(7)(x))
+#define ML99_PRIV_tupleGet_0_IMPL(x) ML99_QUOTE(ML99_TUPLE_GET(0)(x))
+#define ML99_PRIV_tupleGet_1_IMPL(x) ML99_QUOTE(ML99_TUPLE_GET(1)(x))
+#define ML99_PRIV_tupleGet_2_IMPL(x) ML99_QUOTE(ML99_TUPLE_GET(2)(x))
+#define ML99_PRIV_tupleGet_3_IMPL(x) ML99_QUOTE(ML99_TUPLE_GET(3)(x))
+#define ML99_PRIV_tupleGet_4_IMPL(x) ML99_QUOTE(ML99_TUPLE_GET(4)(x))
+#define ML99_PRIV_tupleGet_5_IMPL(x) ML99_QUOTE(ML99_TUPLE_GET(5)(x))
+#define ML99_PRIV_tupleGet_6_IMPL(x) ML99_QUOTE(ML99_TUPLE_GET(6)(x))
+#define ML99_PRIV_tupleGet_7_IMPL(x) ML99_QUOTE(ML99_TUPLE_GET(7)(x))
 
 #define ML99_PRIV_TUPLE_GET_0(x) ML99_VARIADICS_GET(0)(ML99_UNTUPLE(x))
 #define ML99_PRIV_TUPLE_GET_1(x) ML99_VARIADICS_GET(1)(ML99_UNTUPLE(x))
@@ -320,15 +320,15 @@
 #define ML99_PRIV_TUPLE_GET_6(x) ML99_VARIADICS_GET(6)(ML99_UNTUPLE(x))
 #define ML99_PRIV_TUPLE_GET_7(x) ML99_VARIADICS_GET(7)(ML99_UNTUPLE(x))
 
-#define ML99_tupleTail_IMPL(x) v(ML99_TUPLE_TAIL(x))
+#define ML99_tupleTail_IMPL(x) ML99_QUOTE(ML99_TUPLE_TAIL(x))
 
-#define ML99_tupleAppend_IMPL(x, ...)  v(ML99_TUPLE_APPEND(x, __VA_ARGS__))
-#define ML99_tuplePrepend_IMPL(x, ...) v(ML99_TUPLE_PREPEND(x, __VA_ARGS__))
+#define ML99_tupleAppend_IMPL(x, ...)  ML99_QUOTE(ML99_TUPLE_APPEND(x, __VA_ARGS__))
+#define ML99_tuplePrepend_IMPL(x, ...) ML99_QUOTE(ML99_TUPLE_PREPEND(x, __VA_ARGS__))
 #define ML99_tupleForEach_IMPL(f, x)   ML99_variadicsForEach_IMPL(f, ML99_UNTUPLE(x))
 #define ML99_tupleForEachI_IMPL(f, x)  ML99_variadicsForEachI_IMPL(f, ML99_UNTUPLE(x))
 
 #define ML99_assertIsTuple_IMPL(x)                                                                 \
-    ML99_PRIV_IF(ML99_IS_UNTUPLE(x), ML99_PRIV_NOT_TUPLE_ERROR(x), v(ML99_PRIV_EMPTY()))
+    ML99_PRIV_IF(ML99_IS_UNTUPLE(x), ML99_PRIV_NOT_TUPLE_ERROR(x), ML99_QUOTE(ML99_PRIV_EMPTY()))
 
 // clang-format off
 #define ML99_PRIV_NOT_TUPLE_ERROR(x) \

--- a/include/metalang99/util.h
+++ b/include/metalang99/util.h
@@ -19,13 +19,13 @@
  * @code
  * #include <metalang99/util.h>
  *
- * #define ABC123 v(Billie Jean)
+ * #define ABC123 ML99_QUOTE(Billie Jean)
  *
  * // Billie Jean
- * ML99_catEval(v(ABC), v(123))
+ * ML99_catEval(ML99_QUOTE(ABC), ML99_QUOTE(123))
  *
  * // ERROR: 123ABC is not a valid Metalang99 term.
- * ML99_catEval(v(123), v(ABC))
+ * ML99_catEval(ML99_QUOTE(123), ML99_QUOTE(ABC))
  * @endcode
  *
  * @deprecated I have seen no single use case over time. Please, [open an
@@ -44,10 +44,10 @@
  * #define ABC123 Billie Jean
  *
  * // Billie Jean
- * ML99_cat(v(ABC), v(123))
+ * ML99_cat(ML99_QUOTE(ABC), ML99_QUOTE(123))
  *
  * // 123ABC
- * ML99_cat(v(123), v(ABC))
+ * ML99_cat(ML99_QUOTE(123), ML99_QUOTE(ABC))
  * @endcode
  */
 #define ML99_cat(a, b) ML99_call(ML99_cat, a, b)
@@ -71,7 +71,7 @@
  * #include <metalang99/util.h>
  *
  * // "Billie Jean"
- * ML99_stringify(v(Billie Jean))
+ * ML99_stringify(ML99_QUOTE(Billie Jean))
  * @endcode
  */
 #define ML99_stringify(...) ML99_call(ML99_stringify, __VA_ARGS__)
@@ -90,7 +90,7 @@
  * #include <metalang99/util.h>
  *
  * // 1, 2, 3
- * ML99_id(v(1, 2, 3))
+ * ML99_id(ML99_QUOTE(1, 2, 3))
  * @endcode
  */
 #define ML99_id(...) ML99_call(ML99_id, __VA_ARGS__)
@@ -104,7 +104,7 @@
  * #include <metalang99/util.h>
  *
  * // 123
- * ML99_const(v(123), v(5))
+ * ML99_const(ML99_QUOTE(123), ML99_QUOTE(5))
  * @endcode
  */
 #define ML99_const(x, a) ML99_call(ML99_const, x, a)
@@ -118,7 +118,7 @@
  * #include <metalang99/util.h>
  *
  * // ABC123
- * ML99_appl2(ML99_flip(v(ML99_catUnevaluated)), v(123), v(ABC))
+ * ML99_appl2(ML99_flip(ML99_QUOTE(ML99_catUnevaluated)), ML99_QUOTE(123), ML99_QUOTE(ABC))
  * @endcode
  */
 #define ML99_flip(f) ML99_call(ML99_flip, f)
@@ -132,7 +132,7 @@
  * #include <metalang99/util.h>
  *
  * // 1 2 3
- * ML99_uncomma(ML99_QUOTE(v(1), v(2), v(3)))
+ * ML99_uncomma(ML99_QUOTE(ML99_QUOTE(1), ML99_QUOTE(2), ML99_QUOTE(3)))
  * @endcode
  */
 #define ML99_uncomma(...) ML99_call(ML99_uncomma, __VA_ARGS__)
@@ -152,13 +152,13 @@
  * #define F(x) @x
  *
  * // @1 @2 @3
- * ML99_variadicsForEach(ML99_reify(v(F)), v(1, 2, 3))
+ * ML99_variadicsForEach(ML99_reify(ML99_QUOTE(F)), ML99_QUOTE(1, 2, 3))
  * @endcode
  *
  * Without #ML99_reify, you would need to write some additional boilerplate:
  *
  * @code
- * #define F_IMPL(x) v(@x)
+ * #define F_IMPL(x) ML99_QUOTE(@x)
  * #define F_ARITY   1
  * @endcode
  */
@@ -176,7 +176,7 @@
  * #include <metalang99/util.h>
  *
  * // A not-yet implemented error.
- * ML99_todo(v(F))
+ * ML99_todo(ML99_QUOTE(F))
  * @endcode
  *
  * @see [Rust's std::todo\!](https://doc.rust-lang.org/core/macro.todo.html) (thanks for the idea!)
@@ -194,7 +194,7 @@
  * #include <metalang99/util.h>
  *
  * // A not-yet-implemented error.
- * ML99_todoWithMsg(v(F), v("your message"))
+ * ML99_todoWithMsg(ML99_QUOTE(F), ML99_QUOTE("your message"))
  * @endcode
  */
 #define ML99_todoWithMsg(f, message) ML99_call(ML99_todoWithMsg, f, message)
@@ -211,7 +211,7 @@
  * #include <metalang99/util.h>
  *
  * // A not-implemented error.
- * ML99_unimplemented(v(F))
+ * ML99_unimplemented(ML99_QUOTE(F))
  * @endcode
  *
  * @see [Rust's std::unimplemented\!](https://doc.rust-lang.org/core/macro.unimplemented.html)
@@ -230,7 +230,7 @@
  * #include <metalang99/util.h>
  *
  * // A not-implemented error.
- * ML99_unimplementedWithMsg(v(F), v("your message"))
+ * ML99_unimplementedWithMsg(ML99_QUOTE(F), ML99_QUOTE("your message"))
  * @endcode
  */
 #define ML99_unimplementedWithMsg(f, message) ML99_call(ML99_unimplementedWithMsg, f, message)
@@ -383,19 +383,19 @@
 #ifndef DOXYGEN_IGNORE
 
 #define ML99_catEval_IMPL(a, b)      a##b
-#define ML99_cat_IMPL(a, b)          v(a##b)
-#define ML99_cat3_IMPL(a, b, c)      v(a##b##c)
-#define ML99_cat4_IMPL(a, b, c, d)   v(a##b##c##d)
-#define ML99_stringify_IMPL(...)     v(ML99_STRINGIFY(__VA_ARGS__))
-#define ML99_empty_IMPL(...)         v(ML99_EMPTY())
-#define ML99_id_IMPL(...)            v(ML99_ID(__VA_ARGS__))
-#define ML99_const_IMPL(x, _a)       v(x)
+#define ML99_cat_IMPL(a, b)          ML99_QUOTE(a##b)
+#define ML99_cat3_IMPL(a, b, c)      ML99_QUOTE(a##b##c)
+#define ML99_cat4_IMPL(a, b, c, d)   ML99_QUOTE(a##b##c##d)
+#define ML99_stringify_IMPL(...)     ML99_QUOTE(ML99_STRINGIFY(__VA_ARGS__))
+#define ML99_empty_IMPL(...)         ML99_QUOTE(ML99_EMPTY())
+#define ML99_id_IMPL(...)            ML99_QUOTE(ML99_ID(__VA_ARGS__))
+#define ML99_const_IMPL(x, _a)       ML99_QUOTE(x)
 #define ML99_flip_IMPL(f)            ML99_appl_IMPL(ML99_PRIV_flip, f)
 #define ML99_PRIV_flip_IMPL(f, a, b) ML99_appl2_IMPL(f, b, a)
 #define ML99_uncomma_IMPL(...)       __VA_ARGS__
 
 #define ML99_reify_IMPL(f)           ML99_appl_IMPL(ML99_PRIV_reify, f)
-#define ML99_PRIV_reify_IMPL(f, ...) v(f(__VA_ARGS__))
+#define ML99_PRIV_reify_IMPL(f, ...) ML99_QUOTE(f(__VA_ARGS__))
 
 // clang-format off
 #define ML99_todo_IMPL(f) ML99_fatal(f, not yet implemented)

--- a/include/metalang99/variadics.h
+++ b/include/metalang99/variadics.h
@@ -26,7 +26,7 @@
  * #include <metalang99/variadics.h>
  *
  * // 3
- * ML99_variadicsCount(v(~, ~, ~))
+ * ML99_variadicsCount(ML99_QUOTE(~, ~, ~))
  *
  * // 1
  * ML99_variadicsCount()
@@ -43,10 +43,10 @@
  * #include <metalang99/variadics.h>
  *
  * // 1
- * ML99_variadicsIsSingle(v(~))
+ * ML99_variadicsIsSingle(ML99_QUOTE(~))
  *
  * // 0
- * ML99_variadicsIsSingle(v(~, ~, ~))
+ * ML99_variadicsIsSingle(ML99_QUOTE(~, ~, ~))
  * @endcode
  */
 #define ML99_variadicsIsSingle(...) ML99_call(ML99_variadicsIsSingle, __VA_ARGS__)
@@ -62,7 +62,7 @@
  * #include <metalang99/variadics.h>
  *
  * // 2
- * ML99_variadicsGet(1)(v(1, 2, 3))
+ * ML99_variadicsGet(1)(ML99_QUOTE(1, 2, 3))
  * @endcode
  */
 #define ML99_variadicsGet(i) ML99_PRIV_CAT(ML99_PRIV_variadicsGet_, i)
@@ -78,7 +78,7 @@
  * #include <metalang99/variadics.h>
  *
  * // 2, 3
- * ML99_variadicsTail(v(1, 2, 3))
+ * ML99_variadicsTail(ML99_QUOTE(1, 2, 3))
  * @endcode
  */
 #define ML99_variadicsTail(...) ML99_call(ML99_variadicsTail, __VA_ARGS__)
@@ -93,11 +93,11 @@
  * @code
  * #include <metalang99/variadics.h>
  *
- * #define F_IMPL(x) v(@x)
+ * #define F_IMPL(x) ML99_QUOTE(@x)
  * #define F_ARITY   1
  *
  * // @x @y @z
- * ML99_variadicsForEach(v(F), v(x, y, z))
+ * ML99_variadicsForEach(ML99_QUOTE(F), ML99_QUOTE(x, y, z))
  * @endcode
  */
 #define ML99_variadicsForEach(f, ...) ML99_call(ML99_variadicsForEach, f, __VA_ARGS__)
@@ -110,11 +110,11 @@
  * @code
  * #include <metalang99/variadics.h>
  *
- * #define F_IMPL(x, i) v(@x##i)
+ * #define F_IMPL(x, i) ML99_QUOTE(@x##i)
  * #define F_ARITY      2
  *
  * // @x0 @y1 @z2
- * ML99_variadicsForEachI(v(F), v(x, y, z))
+ * ML99_variadicsForEachI(ML99_QUOTE(F), ML99_QUOTE(x, y, z))
  * @endcode
  */
 #define ML99_variadicsForEachI(f, ...) ML99_call(ML99_variadicsForEachI, f, __VA_ARGS__)
@@ -155,8 +155,8 @@
 
 #ifndef DOXYGEN_IGNORE
 
-#define ML99_variadicsCount_IMPL(...)    v(ML99_VARIADICS_COUNT(__VA_ARGS__))
-#define ML99_variadicsIsSingle_IMPL(...) v(ML99_VARIADICS_IS_SINGLE(__VA_ARGS__))
+#define ML99_variadicsCount_IMPL(...)    ML99_QUOTE(ML99_VARIADICS_COUNT(__VA_ARGS__))
+#define ML99_variadicsIsSingle_IMPL(...) ML99_QUOTE(ML99_VARIADICS_IS_SINGLE(__VA_ARGS__))
 
 #define ML99_PRIV_variadicsGet_0(...) ML99_call(ML99_PRIV_variadicsGet_0, __VA_ARGS__)
 #define ML99_PRIV_variadicsGet_1(...) ML99_call(ML99_PRIV_variadicsGet_1, __VA_ARGS__)
@@ -167,14 +167,14 @@
 #define ML99_PRIV_variadicsGet_6(...) ML99_call(ML99_PRIV_variadicsGet_6, __VA_ARGS__)
 #define ML99_PRIV_variadicsGet_7(...) ML99_call(ML99_PRIV_variadicsGet_7, __VA_ARGS__)
 
-#define ML99_PRIV_variadicsGet_0_IMPL(...) v(ML99_VARIADICS_GET(0)(__VA_ARGS__))
-#define ML99_PRIV_variadicsGet_1_IMPL(...) v(ML99_VARIADICS_GET(1)(__VA_ARGS__))
-#define ML99_PRIV_variadicsGet_2_IMPL(...) v(ML99_VARIADICS_GET(2)(__VA_ARGS__))
-#define ML99_PRIV_variadicsGet_3_IMPL(...) v(ML99_VARIADICS_GET(3)(__VA_ARGS__))
-#define ML99_PRIV_variadicsGet_4_IMPL(...) v(ML99_VARIADICS_GET(4)(__VA_ARGS__))
-#define ML99_PRIV_variadicsGet_5_IMPL(...) v(ML99_VARIADICS_GET(5)(__VA_ARGS__))
-#define ML99_PRIV_variadicsGet_6_IMPL(...) v(ML99_VARIADICS_GET(6)(__VA_ARGS__))
-#define ML99_PRIV_variadicsGet_7_IMPL(...) v(ML99_VARIADICS_GET(7)(__VA_ARGS__))
+#define ML99_PRIV_variadicsGet_0_IMPL(...) ML99_QUOTE(ML99_VARIADICS_GET(0)(__VA_ARGS__))
+#define ML99_PRIV_variadicsGet_1_IMPL(...) ML99_QUOTE(ML99_VARIADICS_GET(1)(__VA_ARGS__))
+#define ML99_PRIV_variadicsGet_2_IMPL(...) ML99_QUOTE(ML99_VARIADICS_GET(2)(__VA_ARGS__))
+#define ML99_PRIV_variadicsGet_3_IMPL(...) ML99_QUOTE(ML99_VARIADICS_GET(3)(__VA_ARGS__))
+#define ML99_PRIV_variadicsGet_4_IMPL(...) ML99_QUOTE(ML99_VARIADICS_GET(4)(__VA_ARGS__))
+#define ML99_PRIV_variadicsGet_5_IMPL(...) ML99_QUOTE(ML99_VARIADICS_GET(5)(__VA_ARGS__))
+#define ML99_PRIV_variadicsGet_6_IMPL(...) ML99_QUOTE(ML99_VARIADICS_GET(6)(__VA_ARGS__))
+#define ML99_PRIV_variadicsGet_7_IMPL(...) ML99_QUOTE(ML99_VARIADICS_GET(7)(__VA_ARGS__))
 
 #define ML99_PRIV_VARIADICS_GET_0(...) ML99_PRIV_VARIADICS_GET_AUX_0(__VA_ARGS__, ~)
 #define ML99_PRIV_VARIADICS_GET_1(...) ML99_PRIV_VARIADICS_GET_AUX_1(__VA_ARGS__, ~)
@@ -194,7 +194,7 @@
 #define ML99_PRIV_VARIADICS_GET_AUX_6(_a, _b, _c, _d, _e, _f, g, ...)     g
 #define ML99_PRIV_VARIADICS_GET_AUX_7(_a, _b, _c, _d, _e, _f, _g, h, ...) h
 
-#define ML99_variadicsTail_IMPL(...) v(ML99_VARIADICS_TAIL(__VA_ARGS__))
+#define ML99_variadicsTail_IMPL(...) ML99_QUOTE(ML99_VARIADICS_TAIL(__VA_ARGS__))
 
 // ML99_variadicsForEach_IMPL {
 


### PR DESCRIPTION
Make ML99_QUOTE the primary definition and v() an optional alias that can be disabled by defining ML99_NO_SHORT_NAMES. This resolves conflicts with libraries that use 'v' as an identifier (e.g., Qt).

Fixes #35